### PR TITLE
Empty Result Fix (No File)

### DIFF
--- a/skyreader/result.py
+++ b/skyreader/result.py
@@ -394,6 +394,12 @@ class SkyScanResult:
         filename = self.get_filename(event_metadata, '.npz', output_dir)
 
         try:
+            first = next(iter(self.result.values()))
+        except StopIteration: # no results yet
+            np.savez(filename, **self.result)
+            return Path(filename)
+
+        try:
             metadata_dtype = np.dtype(
                 [
                     (k, type(v)) if not isinstance(v, str) else (k, f"U{len(v)}")

--- a/skyreader/result.py
+++ b/skyreader/result.py
@@ -353,7 +353,11 @@ class SkyScanResult:
         if not extension.startswith('.'):
             extension = '.' + extension
 
-        filename = Path(f"{str(event_metadata)}_{self.get_nside_string()}{extension}")
+        if nside_string := self.get_nside_string():
+            filename = Path(f"{str(event_metadata)}_{nside_string}{extension}")
+        else:
+            raise ValueError("cannot create filename for an empty result")
+
         if output_dir is not None:
             filename = output_dir / Path(filename)
         return filename
@@ -388,12 +392,6 @@ class SkyScanResult:
     ) -> Path:
         """Save to .npz file."""
         filename = self.get_filename(event_metadata, '.npz', output_dir)
-
-        try:
-            first = next(iter(self.result.values()))
-        except StopIteration: # no results yet
-            np.savez(filename, **self.result)
-            return Path(filename)
 
         try:
             metadata_dtype = np.dtype(


### PR DESCRIPTION
Don't create a filename for an empty result because it looks like a final result: `run00127907.evt000020178442.HESE_.json`