### PR TITLE
Update function for plotting map with the last available Fermi LAT source catalog

### DIFF
--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -4,39 +4,41 @@
 #
 #    pip-compile --extra=examples --output-file=dependencies-examples.log
 #
-astropy==5.3.4
+astropy==6.0.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-cachetools==5.3.2
+astropy-iers-data==0.2024.4.22.0.29.50
+    # via astropy
+cachetools==5.3.3
     # via wipac-rest-tools
-certifi==2023.7.22
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
-cryptography==41.0.5
+cryptography==42.0.5
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.44.1
+fonttools==4.51.0
     # via matplotlib
 healpy==1.16.6
     # via icecube-skyreader (setup.py)
-idna==3.4
+idna==3.7
     # via requests
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.4
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.2
+numpy==1.26.4
     # via
     #   astropy
     #   contourpy
@@ -46,31 +48,29 @@ numpy==1.26.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   astropy
     #   matplotlib
-pandas==2.1.3
+pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.1.0
+pillow==10.3.0
     # via matplotlib
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pyerfa==2.0.1.1
+pyerfa==2.0.1.4
     # via astropy
 pyjwt[crypto]==2.8.0
-    # via
-    #   pyjwt
-    #   wipac-rest-tools
-pyparsing==3.1.1
+    # via wipac-rest-tools
+pyparsing==3.1.2
     # via matplotlib
 pypng==0.20220715.0
     # via qrcode
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
@@ -83,25 +83,25 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-scipy==1.11.3
+scipy==1.13.0
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.3
+tornado==6.4
     # via wipac-rest-tools
-typing-extensions==4.8.0
+typing-extensions==4.11.0
     # via
     #   qrcode
     #   wipac-dev-tools
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.1
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.7.1
+wipac-dev-tools==1.9.1
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.6.0
+wipac-rest-tools==1.7.2
     # via icecube-skyreader (setup.py)

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -4,41 +4,43 @@
 #
 #    pip-compile --extra=mypy --output-file=dependencies-mypy.log
 #
-astropy==5.3.4
+astropy==6.0.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-cachetools==5.3.2
+astropy-iers-data==0.2024.4.22.0.29.50
+    # via astropy
+cachetools==5.3.3
     # via wipac-rest-tools
-certifi==2023.7.22
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
-cryptography==41.0.5
+cryptography==42.0.5
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.44.1
+fonttools==4.51.0
     # via matplotlib
 healpy==1.16.6
     # via icecube-skyreader (setup.py)
-idna==3.4
+idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.4
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.2
+numpy==1.26.4
     # via
     #   astropy
     #   contourpy
@@ -48,40 +50,38 @@ numpy==1.26.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   astropy
     #   matplotlib
     #   pytest
-pandas==2.1.3
+pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.1.0
+pillow==10.3.0
     # via matplotlib
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pyerfa==2.0.1.1
+pyerfa==2.0.1.4
     # via astropy
 pyjwt[crypto]==2.8.0
-    # via
-    #   pyjwt
-    #   wipac-rest-tools
-pyparsing==3.1.1
+    # via wipac-rest-tools
+pyparsing==3.1.2
     # via matplotlib
 pypng==0.20220715.0
     # via qrcode
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via icecube-skyreader (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
@@ -94,25 +94,25 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-scipy==1.11.3
+scipy==1.13.0
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.3
+tornado==6.4
     # via wipac-rest-tools
-typing-extensions==4.8.0
+typing-extensions==4.11.0
     # via
     #   qrcode
     #   wipac-dev-tools
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.1
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.7.1
+wipac-dev-tools==1.9.1
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.6.0
+wipac-rest-tools==1.7.2
     # via icecube-skyreader (setup.py)

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -4,35 +4,37 @@
 #
 #    pip-compile --extra=tests --output-file=dependencies-tests.log
 #
-astropy==5.3.4
+astropy==6.0.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-certifi==2023.7.22
+astropy-iers-data==0.2024.4.22.0.29.50
+    # via astropy
+certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.44.1
+fonttools==4.51.0
     # via matplotlib
 healpy==1.16.6
     # via icecube-skyreader (setup.py)
-idna==3.4
+idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.4
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.2
+numpy==1.26.4
     # via
     #   astropy
     #   contourpy
@@ -42,46 +44,46 @@ numpy==1.26.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   astropy
     #   matplotlib
     #   pytest
-pandas==2.1.3
+pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.1.0
+pillow==10.3.0
     # via matplotlib
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-pyerfa==2.0.1.1
+pyerfa==2.0.1.4
     # via astropy
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via matplotlib
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via icecube-skyreader (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
 requests==2.31.0
     # via wipac-dev-tools
-scipy==1.11.3
+scipy==1.13.0
     # via healpy
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.8.0
+typing-extensions==4.11.0
     # via wipac-dev-tools
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.1
     # via requests
-wipac-dev-tools==1.7.1
+wipac-dev-tools==1.9.1
     # via icecube-skyreader (setup.py)

--- a/dependencies.log
+++ b/dependencies.log
@@ -4,33 +4,35 @@
 #
 #    pip-compile --output-file=dependencies.log
 #
-astropy==5.3.4
+astropy==6.0.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-certifi==2023.7.22
+astropy-iers-data==0.2024.4.22.0.29.50
+    # via astropy
+certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.44.1
+fonttools==4.51.0
     # via matplotlib
 healpy==1.16.6
     # via icecube-skyreader (setup.py)
-idna==3.4
+idna==3.7
     # via requests
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.4
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.2
+numpy==1.26.4
     # via
     #   astropy
     #   contourpy
@@ -40,37 +42,37 @@ numpy==1.26.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   astropy
     #   matplotlib
-pandas==2.1.3
+pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.1.0
+pillow==10.3.0
     # via matplotlib
-pyerfa==2.0.1.1
+pyerfa==2.0.1.4
     # via astropy
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via matplotlib
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
 requests==2.31.0
     # via wipac-dev-tools
-scipy==1.11.3
+scipy==1.13.0
     # via healpy
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.8.0
+typing-extensions==4.11.0
     # via wipac-dev-tools
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.1
     # via requests
-wipac-dev-tools==1.7.1
+wipac-dev-tools==1.9.1
     # via icecube-skyreader (setup.py)

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -111,7 +111,7 @@ def plot_catalog(master_map, cmap, lower_ra, upper_ra, lower_dec, upper_dec,
         cmap_min=0., cmap_max=250.):
     """"Plots the 4FGL catalog in a color that contrasts with the background
     healpix map."""
-    hdu = pyfits.open('/cvmfs/icecube.opensciencegrid.org/users/azegarelli/gll_psc_v34.fit') ## LAT 14-year Source Catalog (4FGL-DR4 in FITS format) ; https://fermi.gsfc.nasa.gov/ssc/data/access/lat/14yr_catalog/
+    hdu = pyfits.open('/cvmfs/icecube.opensciencegrid.org/users/azegarelli/realtime/catalogs/gll_psc_v34.fit') ## LAT 14-year Source Catalog (4FGL-DR4 in FITS format) ; https://fermi.gsfc.nasa.gov/ssc/data/access/lat/14yr_catalog/
     fgl = hdu[1]
     pe = [path_effects.Stroke(linewidth=0.5, foreground=cmap(0.0)),
         path_effects.Normal()]

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -111,7 +111,7 @@ def plot_catalog(master_map, cmap, lower_ra, upper_ra, lower_dec, upper_dec,
         cmap_min=0., cmap_max=250.):
     """"Plots the 4FGL catalog in a color that contrasts with the background
     healpix map."""
-    hdu = pyfits.open('/cvmfs/icecube.opensciencegrid.org/users/steinrob/reference_catalogues/Fermi_4FGL_v18.fit')
+    hdu = pyfits.open('/cvmfs/icecube.opensciencegrid.org/users/azegarelli/realtime/catalogs/gll_psc_v34.fit')
     fgl = hdu[1]
     pe = [path_effects.Stroke(linewidth=0.5, foreground=cmap(0.0)),
         path_effects.Normal()]

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -111,7 +111,7 @@ def plot_catalog(master_map, cmap, lower_ra, upper_ra, lower_dec, upper_dec,
         cmap_min=0., cmap_max=250.):
     """"Plots the 4FGL catalog in a color that contrasts with the background
     healpix map."""
-    hdu = pyfits.open('/cvmfs/icecube.opensciencegrid.org/users/azegarelli/realtime/catalogs/gll_psc_v34.fit')
+    hdu = pyfits.open('/cvmfs/icecube.opensciencegrid.org/users/azegarelli/gll_psc_v34.fit') ## LAT 14-year Source Catalog (4FGL-DR4 in FITS format) ; https://fermi.gsfc.nasa.gov/ssc/data/access/lat/14yr_catalog/
     fgl = hdu[1]
     pe = [path_effects.Stroke(linewidth=0.5, foreground=cmap(0.0)),
         path_effects.Normal()]


### PR DESCRIPTION
Hi,

I propose to update the function plotting the 4FGL catalog on the healpix map with the last available FITS file from Fermi LAT:  [LAT 14-year Source Catalog](https://fermi.gsfc.nasa.gov/ssc/data/access/lat/14yr_catalog/gll_psc_v34.fit) (4FGL-DR4) --> 22 Feb 2024

Below, you can see some maps produced for the IceCube Gold Alert IC240424A with `skymist scan plot `(https://github.com/icecube/skymist/blob/fe23cba8d9552e59767de5414b8b7f4600dfef37/src/skymist/skyscan/console.py#L156) by using the current version of skyreader (left) and the one taking the new catalog (right). It is visible that in this latter case the source 4FGL J2146.8+0425, not present in the old catalog, appears. 

<img width="1582" alt="Screenshot 2024-04-25 alle 10 33 22" src="https://github.com/icecube/skyreader/assets/159175351/6b6723e1-e507-4ead-a1d3-7570f18008e9">

