### PR TITLE
Improved area calculation, mock ts maps for circularized contours, and neutrino floor implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!--next-version-placeholder-->
 
+## v1.2.9 (2024-04-25)
+
+### Other
+
+* Update function for plotting map with the last available Fermi LAT source catalog ([#33](https://github.com/icecube/skyreader/issues/33)) ([`8fbce83`](https://github.com/icecube/skyreader/commit/8fbce8301773decaad3bc1278226ad10c21cfc3a))
+
 ## v1.2.8 (2023-11-14)
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!--next-version-placeholder-->
 
+## v1.2.10 (2024-07-21)
+
+### Other
+
+* <bot> update dependencies*.log files(s) ([`eacbc29`](https://github.com/icecube/skyreader/commit/eacbc294a002b5d7ce2294cc68982b5484bd1d84))
+* All plotting outputs to the same directory ([#32](https://github.com/icecube/skyreader/issues/32)) ([`8cee17e`](https://github.com/icecube/skyreader/commit/8cee17ebc7da42b69c60da5e3908fa13fb17872d))
+
 ## v1.2.9 (2024-04-25)
 
 ### Other

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -4,15 +4,15 @@
 #
 #    pip-compile --extra=examples --output-file=dependencies-examples.log
 #
-astropy==6.0.1
+astropy==6.1.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.4.22.0.29.50
+astropy-iers-data==0.2024.7.15.0.31.42
     # via astropy
-cachetools==5.3.3
+cachetools==5.4.0
     # via wipac-rest-tools
-certifi==2024.2.2
+certifi==2024.7.4
     # via requests
 cffi==1.16.0
     # via cryptography
@@ -20,25 +20,23 @@ charset-normalizer==3.3.2
     # via requests
 contourpy==1.2.1
     # via matplotlib
-cryptography==42.0.5
+cryptography==42.0.8
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.51.0
+fonttools==4.53.1
     # via matplotlib
-healpy==1.16.6
+healpy==1.17.3
     # via icecube-skyreader (setup.py)
 idna==3.7
     # via requests
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.4
-    # via
-    #   healpy
-    #   icecube-skyreader (setup.py)
+matplotlib==3.9.1
+    # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   astropy
     #   contourpy
@@ -48,13 +46,13 @@ numpy==1.26.4
     #   pandas
     #   pyerfa
     #   scipy
-packaging==24.0
+packaging==24.1
     # via
     #   astropy
     #   matplotlib
 pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.3.0
+pillow==10.4.0
     # via matplotlib
 pycparser==2.22
     # via cffi
@@ -76,32 +74,32 @@ pyyaml==6.0.1
     # via astropy
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.31.0
+requests==2.32.3
     # via
     #   requests-futures
     #   wipac-dev-tools
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-scipy==1.13.0
-    # via healpy
+scipy==1.14.0
+    # via icecube-skyreader (setup.py)
 six==1.16.0
     # via python-dateutil
-tornado==6.4
+tornado==6.4.1
     # via wipac-rest-tools
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   qrcode
     #   wipac-dev-tools
 tzdata==2024.1
     # via pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.9.1
+wipac-dev-tools==1.10.6
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.7.2
+wipac-rest-tools==1.7.6
     # via icecube-skyreader (setup.py)

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -20,7 +20,7 @@ charset-normalizer==3.3.2
     # via requests
 contourpy==1.2.1
     # via matplotlib
-cryptography==42.0.8
+cryptography==43.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -4,39 +4,41 @@
 #
 #    pip-compile --extra=examples --output-file=dependencies-examples.log
 #
-astropy==5.3.4
+astropy==6.0.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-cachetools==5.3.2
+astropy-iers-data==0.2024.4.22.0.29.50
+    # via astropy
+cachetools==5.3.3
     # via wipac-rest-tools
-certifi==2023.7.22
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
-cryptography==41.0.5
+cryptography==42.0.5
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.44.1
+fonttools==4.51.0
     # via matplotlib
 healpy==1.16.6
     # via icecube-skyreader (setup.py)
-idna==3.4
+idna==3.7
     # via requests
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.4
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.2
+numpy==1.26.4
     # via
     #   astropy
     #   contourpy
@@ -46,31 +48,29 @@ numpy==1.26.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   astropy
     #   matplotlib
-pandas==2.1.3
+pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.1.0
+pillow==10.3.0
     # via matplotlib
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pyerfa==2.0.1.1
+pyerfa==2.0.1.4
     # via astropy
 pyjwt[crypto]==2.8.0
-    # via
-    #   pyjwt
-    #   wipac-rest-tools
-pyparsing==3.1.1
+    # via wipac-rest-tools
+pyparsing==3.1.2
     # via matplotlib
 pypng==0.20220715.0
     # via qrcode
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
@@ -83,25 +83,25 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-scipy==1.11.3
+scipy==1.13.0
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.3
+tornado==6.4
     # via wipac-rest-tools
-typing-extensions==4.8.0
+typing-extensions==4.11.0
     # via
     #   qrcode
     #   wipac-dev-tools
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.1
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.7.1
+wipac-dev-tools==1.9.1
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.6.0
+wipac-rest-tools==1.7.2
     # via icecube-skyreader (setup.py)

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -20,7 +20,7 @@ charset-normalizer==3.3.2
     # via requests
 contourpy==1.2.1
     # via matplotlib
-cryptography==42.0.8
+cryptography==43.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
@@ -69,7 +69,7 @@ pyparsing==3.1.2
     # via matplotlib
 pypng==0.20220715.0
     # via qrcode
-pytest==8.2.2
+pytest==8.3.1
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -4,41 +4,43 @@
 #
 #    pip-compile --extra=mypy --output-file=dependencies-mypy.log
 #
-astropy==5.3.4
+astropy==6.0.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-cachetools==5.3.2
+astropy-iers-data==0.2024.4.22.0.29.50
+    # via astropy
+cachetools==5.3.3
     # via wipac-rest-tools
-certifi==2023.7.22
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
-cryptography==41.0.5
+cryptography==42.0.5
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.44.1
+fonttools==4.51.0
     # via matplotlib
 healpy==1.16.6
     # via icecube-skyreader (setup.py)
-idna==3.4
+idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.4
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.2
+numpy==1.26.4
     # via
     #   astropy
     #   contourpy
@@ -48,40 +50,38 @@ numpy==1.26.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   astropy
     #   matplotlib
     #   pytest
-pandas==2.1.3
+pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.1.0
+pillow==10.3.0
     # via matplotlib
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pyerfa==2.0.1.1
+pyerfa==2.0.1.4
     # via astropy
 pyjwt[crypto]==2.8.0
-    # via
-    #   pyjwt
-    #   wipac-rest-tools
-pyparsing==3.1.1
+    # via wipac-rest-tools
+pyparsing==3.1.2
     # via matplotlib
 pypng==0.20220715.0
     # via qrcode
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via icecube-skyreader (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
@@ -94,25 +94,25 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-scipy==1.11.3
+scipy==1.13.0
     # via healpy
 six==1.16.0
     # via python-dateutil
-tornado==6.3.3
+tornado==6.4
     # via wipac-rest-tools
-typing-extensions==4.8.0
+typing-extensions==4.11.0
     # via
     #   qrcode
     #   wipac-dev-tools
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.1
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.7.1
+wipac-dev-tools==1.9.1
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.6.0
+wipac-rest-tools==1.7.2
     # via icecube-skyreader (setup.py)

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -4,15 +4,15 @@
 #
 #    pip-compile --extra=mypy --output-file=dependencies-mypy.log
 #
-astropy==6.0.1
+astropy==6.1.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.4.22.0.29.50
+astropy-iers-data==0.2024.7.15.0.31.42
     # via astropy
-cachetools==5.3.3
+cachetools==5.4.0
     # via wipac-rest-tools
-certifi==2024.2.2
+certifi==2024.7.4
     # via requests
 cffi==1.16.0
     # via cryptography
@@ -20,13 +20,13 @@ charset-normalizer==3.3.2
     # via requests
 contourpy==1.2.1
     # via matplotlib
-cryptography==42.0.5
+cryptography==42.0.8
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.51.0
+fonttools==4.53.1
     # via matplotlib
-healpy==1.16.6
+healpy==1.17.3
     # via icecube-skyreader (setup.py)
 idna==3.7
     # via requests
@@ -34,13 +34,11 @@ iniconfig==2.0.0
     # via pytest
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.4
-    # via
-    #   healpy
-    #   icecube-skyreader (setup.py)
+matplotlib==3.9.1
+    # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   astropy
     #   contourpy
@@ -50,14 +48,14 @@ numpy==1.26.4
     #   pandas
     #   pyerfa
     #   scipy
-packaging==24.0
+packaging==24.1
     # via
     #   astropy
     #   matplotlib
     #   pytest
 pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.3.0
+pillow==10.4.0
     # via matplotlib
 pluggy==1.5.0
     # via pytest
@@ -71,7 +69,7 @@ pyparsing==3.1.2
     # via matplotlib
 pypng==0.20220715.0
     # via qrcode
-pytest==8.1.1
+pytest==8.2.2
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock
@@ -87,32 +85,32 @@ pyyaml==6.0.1
     # via astropy
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.31.0
+requests==2.32.3
     # via
     #   requests-futures
     #   wipac-dev-tools
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-scipy==1.13.0
-    # via healpy
+scipy==1.14.0
+    # via icecube-skyreader (setup.py)
 six==1.16.0
     # via python-dateutil
-tornado==6.4
+tornado==6.4.1
     # via wipac-rest-tools
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   qrcode
     #   wipac-dev-tools
 tzdata==2024.1
     # via pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.9.1
+wipac-dev-tools==1.10.6
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.7.2
+wipac-rest-tools==1.7.6
     # via icecube-skyreader (setup.py)

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -4,35 +4,37 @@
 #
 #    pip-compile --extra=tests --output-file=dependencies-tests.log
 #
-astropy==5.3.4
+astropy==6.0.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-certifi==2023.7.22
+astropy-iers-data==0.2024.4.22.0.29.50
+    # via astropy
+certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.44.1
+fonttools==4.51.0
     # via matplotlib
 healpy==1.16.6
     # via icecube-skyreader (setup.py)
-idna==3.4
+idna==3.7
     # via requests
 iniconfig==2.0.0
     # via pytest
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.4
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.2
+numpy==1.26.4
     # via
     #   astropy
     #   contourpy
@@ -42,46 +44,46 @@ numpy==1.26.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   astropy
     #   matplotlib
     #   pytest
-pandas==2.1.3
+pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.1.0
+pillow==10.3.0
     # via matplotlib
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-pyerfa==2.0.1.1
+pyerfa==2.0.1.4
     # via astropy
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via matplotlib
-pytest==7.4.3
+pytest==8.1.1
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via icecube-skyreader (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
 requests==2.31.0
     # via wipac-dev-tools
-scipy==1.11.3
+scipy==1.13.0
     # via healpy
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.8.0
+typing-extensions==4.11.0
     # via wipac-dev-tools
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.1
     # via requests
-wipac-dev-tools==1.7.1
+wipac-dev-tools==1.9.1
     # via icecube-skyreader (setup.py)

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -57,7 +57,7 @@ pyerfa==2.0.1.4
     # via astropy
 pyparsing==3.1.2
     # via matplotlib
-pytest==8.2.2
+pytest==8.3.1
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -4,13 +4,13 @@
 #
 #    pip-compile --extra=tests --output-file=dependencies-tests.log
 #
-astropy==6.0.1
+astropy==6.1.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.4.22.0.29.50
+astropy-iers-data==0.2024.7.15.0.31.42
     # via astropy
-certifi==2024.2.2
+certifi==2024.7.4
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -18,9 +18,9 @@ contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.51.0
+fonttools==4.53.1
     # via matplotlib
-healpy==1.16.6
+healpy==1.17.3
     # via icecube-skyreader (setup.py)
 idna==3.7
     # via requests
@@ -28,13 +28,11 @@ iniconfig==2.0.0
     # via pytest
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.4
-    # via
-    #   healpy
-    #   icecube-skyreader (setup.py)
+matplotlib==3.9.1
+    # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   astropy
     #   contourpy
@@ -44,14 +42,14 @@ numpy==1.26.4
     #   pandas
     #   pyerfa
     #   scipy
-packaging==24.0
+packaging==24.1
     # via
     #   astropy
     #   matplotlib
     #   pytest
 pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.3.0
+pillow==10.4.0
     # via matplotlib
 pluggy==1.5.0
     # via pytest
@@ -59,7 +57,7 @@ pyerfa==2.0.1.4
     # via astropy
 pyparsing==3.1.2
     # via matplotlib
-pytest==8.1.1
+pytest==8.2.2
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock
@@ -73,17 +71,17 @@ pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
-requests==2.31.0
+requests==2.32.3
     # via wipac-dev-tools
-scipy==1.13.0
-    # via healpy
+scipy==1.14.0
+    # via icecube-skyreader (setup.py)
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via wipac-dev-tools
 tzdata==2024.1
     # via pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
-wipac-dev-tools==1.9.1
+wipac-dev-tools==1.10.6
     # via icecube-skyreader (setup.py)

--- a/dependencies.log
+++ b/dependencies.log
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=dependencies.log
 #
-astropy==6.0.1
+astropy==6.1.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.4.22.0.29.50
+astropy-iers-data==0.2024.7.15.0.31.42
     # via astropy
-certifi==2024.2.2
+certifi==2024.7.4
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -18,21 +18,19 @@ contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.51.0
+fonttools==4.53.1
     # via matplotlib
-healpy==1.16.6
+healpy==1.17.3
     # via icecube-skyreader (setup.py)
 idna==3.7
     # via requests
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.4
-    # via
-    #   healpy
-    #   icecube-skyreader (setup.py)
+matplotlib==3.9.1
+    # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.4
+numpy==2.0.0
     # via
     #   astropy
     #   contourpy
@@ -42,13 +40,13 @@ numpy==1.26.4
     #   pandas
     #   pyerfa
     #   scipy
-packaging==24.0
+packaging==24.1
     # via
     #   astropy
     #   matplotlib
 pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.3.0
+pillow==10.4.0
     # via matplotlib
 pyerfa==2.0.1.4
     # via astropy
@@ -62,17 +60,17 @@ pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
-requests==2.31.0
+requests==2.32.3
     # via wipac-dev-tools
-scipy==1.13.0
-    # via healpy
+scipy==1.14.0
+    # via icecube-skyreader (setup.py)
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via wipac-dev-tools
 tzdata==2024.1
     # via pandas
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
-wipac-dev-tools==1.9.1
+wipac-dev-tools==1.10.6
     # via icecube-skyreader (setup.py)

--- a/dependencies.log
+++ b/dependencies.log
@@ -4,33 +4,35 @@
 #
 #    pip-compile --output-file=dependencies.log
 #
-astropy==5.3.4
+astropy==6.0.1
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-certifi==2023.7.22
+astropy-iers-data==0.2024.4.22.0.29.50
+    # via astropy
+certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
-contourpy==1.2.0
+contourpy==1.2.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.44.1
+fonttools==4.51.0
     # via matplotlib
 healpy==1.16.6
     # via icecube-skyreader (setup.py)
-idna==3.4
+idna==3.7
     # via requests
 kiwisolver==1.4.5
     # via matplotlib
-matplotlib==3.8.1
+matplotlib==3.8.4
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==1.26.2
+numpy==1.26.4
     # via
     #   astropy
     #   contourpy
@@ -40,37 +42,37 @@ numpy==1.26.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==23.2
+packaging==24.0
     # via
     #   astropy
     #   matplotlib
-pandas==2.1.3
+pandas==2.2.2
     # via icecube-skyreader (setup.py)
-pillow==10.1.0
+pillow==10.3.0
     # via matplotlib
-pyerfa==2.0.1.1
+pyerfa==2.0.1.4
     # via astropy
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via matplotlib
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2023.3.post1
+pytz==2024.1
     # via pandas
 pyyaml==6.0.1
     # via astropy
 requests==2.31.0
     # via wipac-dev-tools
-scipy==1.11.3
+scipy==1.13.0
     # via healpy
 six==1.16.0
     # via python-dateutil
-typing-extensions==4.8.0
+typing-extensions==4.11.0
     # via wipac-dev-tools
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
-urllib3==2.1.0
+urllib3==2.2.1
     # via requests
-wipac-dev-tools==1.7.1
+wipac-dev-tools==1.9.1
     # via icecube-skyreader (setup.py)

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
 	meander
 	numpy
 	pandas
+	scipy
 	wipac-dev-tools
 python_requires = >=3.8, <3.13
 packages = find:

--- a/skyreader/__init__.py
+++ b/skyreader/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-__version__ = "1.2.9"
+__version__ = "1.2.10"
 version_info = (
     int(__version__.split(".")[0]),
     int(__version__.split(".")[1]),

--- a/skyreader/__init__.py
+++ b/skyreader/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-__version__ = "1.2.8"
+__version__ = "1.2.9"
 version_info = (
     int(__version__.split(".")[0]),
     int(__version__.split(".")[1]),

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -617,8 +617,8 @@ class SkyScanPlotter:
             tab = {"ra (rad)": ras, "dec (rad)": decs}
             savename = unique_id + ".contour_" + val + ".txt"
             try:
-                LOGGER.info("Dumping to {savename}")
-                ascii.write(tab, savename, overwrite=True)
+                LOGGER.info("Dumping to {self.output_dir / savename}")
+                ascii.write(tab, self.output_dir / savename, overwrite=True)
             except OSError as err:
                 LOGGER.error("OS Error prevented contours from being written, maybe a memory issue. Error is:\n{err}")
 
@@ -670,12 +670,12 @@ class SkyScanPlotter:
 
 
         # Dump the whole contour
-        path = unique_id + ".contour.pkl"
-        print("Saving contour to", path)
-        with open(path, "wb") as f:
+        pickle_path = self.output_dir / (unique_id + ".contour.pkl")
+        LOGGER.info(f"Saving contour to {pickle_path}")
+        with open(pickle_path, "wb") as f:
             pickle.dump(saving_contours, f)
 
-        healpy.write_map(f"{unique_id}.skymap_nside_{mmap_nside}.fits.gz",
+        healpy.write_map(self.output_dir / f"{unique_id}.skymap_nside_{mmap_nside}.fits.gz",
             equatorial_map, coord = 'C', column_names = ['2LLH'],
             extra_header = fits_header, overwrite=True)
 

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -111,7 +111,7 @@ def plot_catalog(master_map, cmap, lower_ra, upper_ra, lower_dec, upper_dec,
         cmap_min=0., cmap_max=250.):
     """"Plots the 4FGL catalog in a color that contrasts with the background
     healpix map."""
-    hdu = pyfits.open('/cvmfs/icecube.opensciencegrid.org/users/steinrob/reference_catalogues/Fermi_4FGL_v18.fit')
+    hdu = pyfits.open('/cvmfs/icecube.opensciencegrid.org/users/azegarelli/realtime/catalogs/gll_psc_v34.fit') ## LAT 14-year Source Catalog (4FGL-DR4 in FITS format) ; https://fermi.gsfc.nasa.gov/ssc/data/access/lat/14yr_catalog/
     fgl = hdu[1]
     pe = [path_effects.Stroke(linewidth=0.5, foreground=cmap(0.0)),
         path_effects.Normal()]


### PR DESCRIPTION
This pull request would introduce three main changes/new implementations:

1. **Improved area calculation**. The estimation with Gauss-Green's theorem takes now into account the spherical space. The estimation by counting pixels is therefore now dropped.
2. **Mock ts maps for circularized contours**. A new parameter, `circularized_ts_map`, is now introduced. As default it is False, but if set to True it produces a circularized ts map with a bi-variate Gaussian shape and centered on the best-fit direction. The standard deviation of the bi-variate Gaussian is estimated from `circular_err90` such as the contour with 90% coverage is at a radius equal to `circular_err90`.
3. **Neutrino floor implementation**. Also in this case there is a new parameter, `neutrino_floor`, by default set as False. If set into True it checks the area of the 90% contour. If it is smaller than what expected in case of neutrino floor (as implemented offline, a bi-variate Gaussian with sigma=0.2 degrees), it sets `circularized_ts_map` to True and `circular_err90` to the correct value for having sigma=0.2 degrees.