### PR TITLE
Multiorder maps

### DIFF
--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -4,11 +4,11 @@
 #
 #    pip-compile --extra=examples --output-file=dependencies-examples.log
 #
-astropy==6.1.4
+astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.10.14.0.32.55
+astropy-iers-data==0.2024.12.2.0.35.34
     # via astropy
 cachetools==5.5.0
     # via wipac-rest-tools
@@ -18,25 +18,25 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.0
     # via requests
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-cryptography==43.0.1
+cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
-healpy==1.17.3
+healpy==1.18.0
     # via icecube-skyreader (setup.py)
 idna==3.10
     # via requests
 kiwisolver==1.4.7
     # via matplotlib
-matplotlib==3.9.2
+matplotlib==3.9.3
     # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==2.1.2
+numpy==2.1.3
     # via
     #   astropy
     #   contourpy
@@ -46,19 +46,19 @@ numpy==2.1.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==24.1
+packaging==24.2
     # via
     #   astropy
     #   matplotlib
 pandas==2.2.3
     # via icecube-skyreader (setup.py)
-pillow==10.4.0
+pillow==11.0.0
     # via matplotlib
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
-pyjwt[crypto]==2.9.0
+pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
 pyparsing==3.2.0
     # via matplotlib
@@ -77,13 +77,13 @@ requests==2.32.3
     #   requests-futures
     #   wipac-dev-tools
     #   wipac-rest-tools
-requests-futures==1.0.1
+requests-futures==1.0.2
     # via wipac-rest-tools
 scipy==1.14.1
     # via icecube-skyreader (setup.py)
 six==1.16.0
     # via python-dateutil
-tornado==6.4.1
+tornado==6.4.2
     # via wipac-rest-tools
 typing-extensions==4.12.2
     # via wipac-dev-tools
@@ -97,5 +97,5 @@ wipac-dev-tools==1.13.0
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.8.0
+wipac-rest-tools==1.8.2
     # via icecube-skyreader (setup.py)

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -85,7 +85,7 @@ requests-futures==1.0.2
     # via wipac-rest-tools
 scipy==1.14.1
     # via icecube-skyreader (setup.py)
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 tornado==6.4.2
     # via wipac-rest-tools

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -24,7 +24,7 @@ cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.0
+fonttools==4.55.1
     # via matplotlib
 healpy==1.18.0
     # via icecube-skyreader (setup.py)

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -27,7 +27,9 @@ cycler==0.12.1
 fonttools==4.55.1
     # via matplotlib
 healpy==1.18.0
-    # via icecube-skyreader (setup.py)
+    # via
+    #   icecube-skyreader (setup.py)
+    #   mhealpy
 idna==3.10
     # via requests
 kiwisolver==1.4.7
@@ -35,6 +37,8 @@ kiwisolver==1.4.7
 matplotlib==3.9.3
     # via icecube-skyreader (setup.py)
 meander==0.0.3
+    # via icecube-skyreader (setup.py)
+mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
 numpy==2.1.3
     # via

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -96,7 +96,7 @@ requests-futures==1.0.2
     # via wipac-rest-tools
 scipy==1.14.1
     # via icecube-skyreader (setup.py)
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 tornado==6.4.2
     # via wipac-rest-tools

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -27,7 +27,9 @@ cycler==0.12.1
 fonttools==4.55.1
     # via matplotlib
 healpy==1.18.0
-    # via icecube-skyreader (setup.py)
+    # via
+    #   icecube-skyreader (setup.py)
+    #   mhealpy
 idna==3.10
     # via requests
 iniconfig==2.0.0
@@ -37,6 +39,8 @@ kiwisolver==1.4.7
 matplotlib==3.9.3
     # via icecube-skyreader (setup.py)
 meander==0.0.3
+    # via icecube-skyreader (setup.py)
+mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
 numpy==2.1.3
     # via

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -4,11 +4,11 @@
 #
 #    pip-compile --extra=mypy --output-file=dependencies-mypy.log
 #
-astropy==6.1.4
+astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.10.14.0.32.55
+astropy-iers-data==0.2024.12.2.0.35.34
     # via astropy
 cachetools==5.5.0
     # via wipac-rest-tools
@@ -18,15 +18,15 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.0
     # via requests
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
-cryptography==43.0.1
+cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
-healpy==1.17.3
+healpy==1.18.0
     # via icecube-skyreader (setup.py)
 idna==3.10
     # via requests
@@ -34,11 +34,11 @@ iniconfig==2.0.0
     # via pytest
 kiwisolver==1.4.7
     # via matplotlib
-matplotlib==3.9.2
+matplotlib==3.9.3
     # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==2.1.2
+numpy==2.1.3
     # via
     #   astropy
     #   contourpy
@@ -48,26 +48,26 @@ numpy==2.1.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==24.1
+packaging==24.2
     # via
     #   astropy
     #   matplotlib
     #   pytest
 pandas==2.2.3
     # via icecube-skyreader (setup.py)
-pillow==10.4.0
+pillow==11.0.0
     # via matplotlib
 pluggy==1.5.0
     # via pytest
 pycparser==2.22
     # via cffi
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
-pyjwt[crypto]==2.9.0
+pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
 pyparsing==3.2.0
     # via matplotlib
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock
@@ -88,13 +88,13 @@ requests==2.32.3
     #   requests-futures
     #   wipac-dev-tools
     #   wipac-rest-tools
-requests-futures==1.0.1
+requests-futures==1.0.2
     # via wipac-rest-tools
 scipy==1.14.1
     # via icecube-skyreader (setup.py)
 six==1.16.0
     # via python-dateutil
-tornado==6.4.1
+tornado==6.4.2
     # via wipac-rest-tools
 typing-extensions==4.12.2
     # via wipac-dev-tools
@@ -108,5 +108,5 @@ wipac-dev-tools==1.13.0
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.8.0
+wipac-rest-tools==1.8.2
     # via icecube-skyreader (setup.py)

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -24,7 +24,7 @@ cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.0
+fonttools==4.55.1
     # via matplotlib
 healpy==1.18.0
     # via icecube-skyreader (setup.py)

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -21,7 +21,9 @@ cycler==0.12.1
 fonttools==4.55.1
     # via matplotlib
 healpy==1.18.0
-    # via icecube-skyreader (setup.py)
+    # via
+    #   icecube-skyreader (setup.py)
+    #   mhealpy
 idna==3.10
     # via requests
 iniconfig==2.0.0
@@ -31,6 +33,8 @@ kiwisolver==1.4.7
 matplotlib==3.9.3
     # via icecube-skyreader (setup.py)
 meander==0.0.3
+    # via icecube-skyreader (setup.py)
+mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
 numpy==2.1.3
     # via

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -18,7 +18,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.0
+fonttools==4.55.1
     # via matplotlib
 healpy==1.18.0
     # via icecube-skyreader (setup.py)

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -79,7 +79,7 @@ requests==2.32.3
     # via wipac-dev-tools
 scipy==1.14.1
     # via icecube-skyreader (setup.py)
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 typing-extensions==4.12.2
     # via wipac-dev-tools

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -4,23 +4,23 @@
 #
 #    pip-compile --extra=tests --output-file=dependencies-tests.log
 #
-astropy==6.1.4
+astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.10.14.0.32.55
+astropy-iers-data==0.2024.12.2.0.35.34
     # via astropy
 certifi==2024.8.30
     # via requests
 charset-normalizer==3.4.0
     # via requests
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
-healpy==1.17.3
+healpy==1.18.0
     # via icecube-skyreader (setup.py)
 idna==3.10
     # via requests
@@ -28,11 +28,11 @@ iniconfig==2.0.0
     # via pytest
 kiwisolver==1.4.7
     # via matplotlib
-matplotlib==3.9.2
+matplotlib==3.9.3
     # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==2.1.2
+numpy==2.1.3
     # via
     #   astropy
     #   contourpy
@@ -42,22 +42,22 @@ numpy==2.1.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==24.1
+packaging==24.2
     # via
     #   astropy
     #   matplotlib
     #   pytest
 pandas==2.2.3
     # via icecube-skyreader (setup.py)
-pillow==10.4.0
+pillow==11.0.0
     # via matplotlib
 pluggy==1.5.0
     # via pytest
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pyparsing==3.2.0
     # via matplotlib
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   icecube-skyreader (setup.py)
     #   pytest-mock

--- a/dependencies.log
+++ b/dependencies.log
@@ -18,7 +18,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.0
+fonttools==4.55.1
     # via matplotlib
 healpy==1.18.0
     # via icecube-skyreader (setup.py)

--- a/dependencies.log
+++ b/dependencies.log
@@ -21,7 +21,9 @@ cycler==0.12.1
 fonttools==4.55.1
     # via matplotlib
 healpy==1.18.0
-    # via icecube-skyreader (setup.py)
+    # via
+    #   icecube-skyreader (setup.py)
+    #   mhealpy
 idna==3.10
     # via requests
 kiwisolver==1.4.7
@@ -29,6 +31,8 @@ kiwisolver==1.4.7
 matplotlib==3.9.3
     # via icecube-skyreader (setup.py)
 meander==0.0.3
+    # via icecube-skyreader (setup.py)
+mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
 numpy==2.1.3
     # via

--- a/dependencies.log
+++ b/dependencies.log
@@ -4,33 +4,33 @@
 #
 #    pip-compile --output-file=dependencies.log
 #
-astropy==6.1.4
+astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.10.14.0.32.55
+astropy-iers-data==0.2024.12.2.0.35.34
     # via astropy
 certifi==2024.8.30
     # via requests
 charset-normalizer==3.4.0
     # via requests
-contourpy==1.3.0
+contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.54.1
+fonttools==4.55.0
     # via matplotlib
-healpy==1.17.3
+healpy==1.18.0
     # via icecube-skyreader (setup.py)
 idna==3.10
     # via requests
 kiwisolver==1.4.7
     # via matplotlib
-matplotlib==3.9.2
+matplotlib==3.9.3
     # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
-numpy==2.1.2
+numpy==2.1.3
     # via
     #   astropy
     #   contourpy
@@ -40,15 +40,15 @@ numpy==2.1.2
     #   pandas
     #   pyerfa
     #   scipy
-packaging==24.1
+packaging==24.2
     # via
     #   astropy
     #   matplotlib
 pandas==2.2.3
     # via icecube-skyreader (setup.py)
-pillow==10.4.0
+pillow==11.0.0
     # via matplotlib
-pyerfa==2.0.1.4
+pyerfa==2.0.1.5
     # via astropy
 pyparsing==3.2.0
     # via matplotlib

--- a/dependencies.log
+++ b/dependencies.log
@@ -68,7 +68,7 @@ requests==2.32.3
     # via wipac-dev-tools
 scipy==1.14.1
     # via icecube-skyreader (setup.py)
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 typing-extensions==4.12.2
     # via wipac-dev-tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ branch = main
 install_requires =
 	astropy
 	healpy
+	mhealpy
 	matplotlib
 	meander
 	numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,9 +49,9 @@ branch = main
 install_requires =
 	astropy
 	healpy
-	mhealpy
 	matplotlib
 	meander
+	mhealpy
 	numpy
 	pandas
 	scipy

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import List, Union
 
 import healpy  # type: ignore[import]
-import mhealpy
+import mhealpy  # type: ignore[import]
 import matplotlib  # type: ignore[import]
 import meander  # type: ignore[import]
 import numpy as np

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -862,11 +862,12 @@ class SkyScanPlotter:
         )
         # save multiorder version of the map
         multiorder_map = mhealpy.HealpixMap(
-            grid_value, uniq_array
+            grid_value / healpy.nside2pixarea(max_nside), uniq_array
         )
+        column_names = [f"{column_names[0]} DENSITY [deg-2]"]
         multiorder_map.write_map(
             f"{unique_id}.skymap_nside_{mmap_nside}_{type_map}.multiorder.fits.gz",
-            column_names=["PROBABILITY"],
+            column_names=column_names,
             extra_header=fits_header,
             overwrite=True,
         )

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -862,7 +862,9 @@ class SkyScanPlotter:
         )
         # save multiorder version of the map
         multiorder_map = mhealpy.HealpixMap(
-            grid_value / healpy.nside2pixarea(max_nside), uniq_array
+            grid_value / healpy.nside2pixarea(
+                max_nside, degrees=True,
+            ), uniq_array
         )
         column_names = [f"{column_names[0]} DENSITY [deg-2]"]
         multiorder_map.write_map(

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -101,7 +101,7 @@ class SkyScanPlotter:
             llh_map,
             angular_error_floor,
             remove_min_val=not llh_map,
-            return_uniqs = False,
+            return_uniqs=False,
         )
 
         grid_pix = healpy.ang2pix(max(nsides), np.pi/2. - DEC, RA)
@@ -718,7 +718,6 @@ class SkyScanPlotter:
             # join end to beginning
             bounding_ras_list.append(bounding_ras_list[0])
             bounding_decs_list.append(bounding_decs_list[0])
-
             bounding_ras: np.ndarray = np.asarray(bounding_ras_list)
             bounding_decs: np.ndarray = np.asarray(bounding_decs_list)
             bounding_phi = np.radians(bounding_ras)
@@ -738,7 +737,6 @@ class SkyScanPlotter:
                 linestyle='dashed',
                 label=contour_label
             )
-
         # Output contours in RA, dec instead of theta, phi
         saving_contours: list = []
         for contours in contours_by_level:
@@ -750,7 +748,6 @@ class SkyScanPlotter:
                 decs = np.pi/2 - theta
                 for tmp_ra, tmp_dec in zip(ras, decs):
                     saving_contours[-1][-1].append([tmp_ra, tmp_dec])
-
         # Save the individual contours, send messages
         for i, val in enumerate(["50", "90"]):
             ras = list(np.asarray(saving_contours[i][0]).T[0])
@@ -782,18 +779,15 @@ class SkyScanPlotter:
 
         # Plot the original online reconstruction location
         if np.sum(np.isnan([extra_ra, extra_dec, extra_radius])) == 0:
-
             # dist = angular_distance(minRA, minDec, extra_ra * np.pi/180.,
             # extra_dec * np.pi/180.)
             # print("Millipede best fit is", dist /(np.pi *
             # extra_radius/(1.177 * 180.)), "sigma from reported best fit")
-
             extra_ra_rad = np.radians(extra_ra)
             extra_dec_rad = np.radians(extra_dec)
             extra_radius_rad = np.radians(extra_radius)
             extra_lon = extra_ra_rad
             extra_lat = extra_dec_rad
-
             healpy.projscatter(
                 np.degrees(extra_lon),
                 np.degrees(extra_lat),
@@ -822,9 +816,7 @@ class SkyScanPlotter:
                     color=cont_col,
                     linestyle=cont_sty
                 )
-
         plt.legend(fontsize=6, loc="lower left")
-
         # Dump the whole contour
         path = unique_id + ".contour.pkl"
         print("Saving contour to", path)
@@ -835,9 +827,7 @@ class SkyScanPlotter:
             column_names = ['2DLLH']
         else:
             # avoid excessively heavy data format for the flattened map
-            equatorial_map[
-                equatorial_map < 1e-16
-            ] = np.mean(
+            equatorial_map[equatorial_map < 1e-16] = np.mean(
                 equatorial_map[equatorial_map < 1e-16]
             )
             column_names = ["PROBABILITY"]

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -97,7 +97,11 @@ class SkyScanPlotter:
         (
             grid_value, grid_ra, grid_dec, equatorial_map
         ) = extract_map(
-            result, llh_map, angular_error_floor, remove_min_val=not llh_map
+            result,
+            llh_map,
+            angular_error_floor,
+            remove_min_val=not llh_map,
+            return_uniqs = False,
         )
 
         grid_pix = healpy.ang2pix(max(nsides), np.pi/2. - DEC, RA)

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -16,7 +16,9 @@ from matplotlib.transforms import Affine2D  # type: ignore[import]
 
 matplotlib.use('agg')
 
-def format_fits_header(event_id_tuple, mjd, ra, dec, uncertainty, llh_map):
+def format_fits_header(
+    event_id_tuple, mjd, ra, dec, uncertainty, llh_map,
+):
     """Prepare some of the relevant event information for a fits file
     header."""
     run_id, event_id, event_type = event_id_tuple
@@ -24,7 +26,7 @@ def format_fits_header(event_id_tuple, mjd, ra, dec, uncertainty, llh_map):
     if llh_map:
         uncertainty_comment = 'Change in 2LLH based on Wilks theorem'
     else:
-        uncertainty_comment = 'Probability-per-pixel (all pixels with same area)'
+        uncertainty_comment = 'Area with 50%(90%) total probability'
 
     header = [
         ('RUNID', run_id),

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -15,6 +15,7 @@ def extract_map(
         llh_map: bool = True,
         angular_error_floor: Union[None, float] = None,
         remove_min_val: bool = True,
+        return_uniqs: bool = True,
 ):
     """
     Extract from the output of skymap_scanner the healpy map
@@ -26,6 +27,8 @@ def extract_map(
             sigma of the gaussian to convolute the map with in deg.
         - remove_min_val: bool = True. Remove minimum value from -llh
           no effect if probability map.
+        - return_uniqs: bool = True. Return the uniqs for each pixel
+            (useful for multiorder maps)
 
     returns:
         - grid_value: value-per-scanned-pixel (pixels with
@@ -34,6 +37,7 @@ def extract_map(
         - grid_dec: declination for each pixel in grid_value
         - equatorial_map: healpix map with maximum nside (all pixels
             with same nside)
+        - uniq_array: uniqs for all the pixels of the map (optional)
     """
 
     grid_map = dict()
@@ -138,7 +142,10 @@ def extract_map(
         grid_value[np.isnan(grid_value)] = min_map
         grid_value = grid_value.clip(min_map, None)
 
-    return grid_value, grid_ra, grid_dec, equatorial_map, uniq_array
+    if return_uniqs:
+        return grid_value, grid_ra, grid_dec, equatorial_map, uniq_array
+    else:
+        return grid_value, grid_ra, grid_dec, equatorial_map
 
 
 def get_contour_levels(

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -71,6 +71,20 @@ def extract_map(
             tmp_dec = np.pi/2 - tmp_theta
             tmp_ra = tmp_phi
             grid_map[(tmp_dec, tmp_ra)] = value
+        
+        if nside == nsides[0]:
+            tot_npix = healpy.nside2npix(nside)
+            if tot_npix < len(results_nside):
+                ring_pixels = np.arange(tot_npix)
+                nest_pixels = healpy.ring2nest(nside, ring_pixels)
+                uniq_pixels = mhealpy.nest2uniq(nside, nest_pixels)
+                for uni, rin in zip(uniq_pixels, nest_pixels):
+                    if uni not in uniq_list:
+                        uniq_list.append(uni)
+                        tmp_theta, tmp_phi = healpy.pix2ang(nside, rin)
+                        tmp_dec = np.pi/2 - tmp_theta
+                        tmp_ra = tmp_phi
+                        grid_map[(tmp_dec, tmp_ra)] = np.nan
 
         LOGGER.info(f"done with map for nside {nside}...")
 

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -117,9 +117,10 @@ def extract_map(
         equatorial_map = equatorial_map / np.nansum(equatorial_map)
 
         # nan values are a problem for the convolution and the contours
-        min_map = np.nanmin(equatorial_map)
+        min_map = np.nanmin(equatorial_map[equatorial_map > 0.])
         print(f"the minimum of the map is {min_map}")
         equatorial_map[np.isnan(equatorial_map)] = min_map
+        equatorial_map[equatorial_map == 0.] = min_map
 
         if angular_error_floor is not None:
             # convolute with a gaussian. angular_error_floor is the

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -40,6 +40,7 @@ def extract_map(
     nsides = result.nsides
     max_nside = max(nsides)
     equatorial_map = np.full(healpy.nside2npix(max_nside), np.nan)
+    uniq_list = list()
 
     for nside in nsides:
         LOGGER.info(f"constructing map for nside {nside}...")
@@ -57,16 +58,14 @@ def extract_map(
         for pixel_data in result.result[f"nside-{nside}"]:
             pixel = pixel_data['index']
             value = pixel_data['llh']
-            if np.isfinite(value) and not np.isnan(value):
-                tmp_theta, tmp_phi = healpy.pix2ang(nside, pixel)
-                tmp_dec = np.pi/2 - tmp_theta
-                tmp_ra = tmp_phi
-                grid_map[(tmp_dec, tmp_ra)] = value
-                # nested_pixel = healpy.ang2pix(
-                #     nside, tmp_theta, tmp_phi, nest=True
-                # )
-                # uniq = 4*nside*nside + nested_pixel
-                # uniq_list.append(uniq)
+            nested_pixel = healpy.ring2nest(nside, pixel)
+            uniq = 4*nside*nside + nested_pixel
+            uniq_list.append(uniq)
+            #if np.isfinite(value) and not np.isnan(value):
+            tmp_theta, tmp_phi = healpy.pix2ang(nside, pixel)
+            tmp_dec = np.pi/2 - tmp_theta
+            tmp_ra = tmp_phi
+            grid_map[(tmp_dec, tmp_ra)] = value
         LOGGER.info(f"done with map for nside {nside}...")
 
     grid_dec_list, grid_ra_list, grid_value_list = [], [], []

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -105,24 +105,24 @@ def extract_map(
         equatorial_map = np.exp(-1. * equatorial_map)
         equatorial_map = equatorial_map / np.nansum(equatorial_map)
 
-        # nan values are a problem for the convolution and the contours
-        min_map = np.nanmin(equatorial_map)
+    # nan values are a problem for the convolution and the contours
+    min_map = np.nanmin(equatorial_map)
+    equatorial_map[np.isnan(equatorial_map)] = min_map
+
+    if angular_error_floor is not None and not llh_map:
+        # convolute with a gaussian. angular_error_floor is the
+        # sigma in deg.
+        equatorial_map = healpy.smoothing(
+            equatorial_map,
+            sigma=np.deg2rad(angular_error_floor),
+        )
+
+        # normalize map
+        min_map = np.nanmin(equatorial_map[equatorial_map > 0.0])
         equatorial_map[np.isnan(equatorial_map)] = min_map
-
-        if angular_error_floor is not None:
-            # convolute with a gaussian. angular_error_floor is the
-            # sigma in deg.
-            equatorial_map = healpy.smoothing(
-                equatorial_map,
-                sigma=np.deg2rad(angular_error_floor),
-            )
-
-            # normalize map
-            min_map = np.nanmin(equatorial_map[equatorial_map > 0.0])
-            equatorial_map[np.isnan(equatorial_map)] = min_map
-            equatorial_map = equatorial_map.clip(min_map, None)
-            normalization = np.nansum(equatorial_map)
-            equatorial_map = equatorial_map / normalization
+        equatorial_map = equatorial_map.clip(min_map, None)
+        normalization = np.nansum(equatorial_map)
+        equatorial_map = equatorial_map / normalization
 
         # obtain values for grid map
         grid_value = healpy.get_interp_val(

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -75,10 +75,11 @@ def extract_map(
         if nside == nsides[0]:
             tot_npix = healpy.nside2npix(nside)
             if tot_npix < len(results_nside):
+                print(f"Filling nside {nside}")
                 ring_pixels = np.arange(tot_npix)
                 nest_pixels = healpy.ring2nest(nside, ring_pixels)
                 uniq_pixels = mhealpy.nest2uniq(nside, nest_pixels)
-                for uni, rin in zip(uniq_pixels, nest_pixels):
+                for uni, rin in zip(uniq_pixels, ring_pixels):
                     if uni not in uniq_list:
                         uniq_list.append(uni)
                         tmp_theta, tmp_phi = healpy.pix2ang(nside, rin)

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -113,7 +113,7 @@ def extract_map(
         grid_value = grid_value.clip(None, max_map)
     else:
         # Convert to probability
-        equatorial_map = np.exp(-1. * equatorial_map)
+        equatorial_map = np.exp(-1. * equatorial_map, dtype='float128')
         equatorial_map = equatorial_map / np.nansum(equatorial_map)
 
         # nan values are a problem for the convolution and the contours

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -74,6 +74,7 @@ def extract_map(
         
         if nside == nsides[0]:
             tot_npix = healpy.nside2npix(nside)
+            print(f"tot_npix: {tot_npix}\nlen(resuls_nside): {len(results_nside)}")
             if tot_npix < len(results_nside):
                 print(f"Filling nside {nside}")
                 ring_pixels = np.arange(tot_npix)

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -118,6 +118,7 @@ def extract_map(
 
         # nan values are a problem for the convolution and the contours
         min_map = np.nanmin(equatorial_map)
+        print(f"the minimum of the map is {min_map}")
         equatorial_map[np.isnan(equatorial_map)] = min_map
 
         if angular_error_floor is not None:

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -2,7 +2,7 @@ from typing import Union
 import logging
 
 import healpy  # type: ignore[import]
-import mhealpy # type: ignore[import]
+import mhealpy  # type: ignore[import]
 import numpy as np
 
 from ..result import SkyScanResult
@@ -71,7 +71,7 @@ def extract_map(
             tmp_dec = np.pi/2 - tmp_theta
             tmp_ra = tmp_phi
             grid_map[(tmp_dec, tmp_ra)] = value
-        
+
         # In case of pointed scans, it helps filling the first nside
         # with empty pixels (especially for saving the multiorder map)
         if nside == nsides[0]:
@@ -232,10 +232,11 @@ def get_contour_levels(
 
     return contour_levels, contour_labels, contour_colors
 
+
 def find_pixels_double_nside(
-        nside: int,
-        indexes: np.ndarray,
-    ):
+    nside: int,
+    indexes: np.ndarray,
+):
     """
     Given indexes of pixels at a given nside, find which are
     the pixels inside these pixels with a double nside
@@ -258,11 +259,12 @@ def find_pixels_double_nside(
     )
     return idxs_inside
 
+
 def already_filled_uniqs_for_nside(
-        nside: int,
-        next_nside: int,
-        uniqs: np.ndarray
-    ):
+    nside: int,
+    next_nside: int,
+    uniqs: np.ndarray
+):
     """
     Check if among the input uniqs there are pixels at a finer nside
     which are inside other pixels with a bigger nside
@@ -273,7 +275,7 @@ def already_filled_uniqs_for_nside(
         -next_nside: int. nside of the finer pixes which we want to see
             if they are inside the coarser pixels
         -uniqs: np.ndarray. Uniqs for all the pixels in the map
-    
+
     returns:
         already_filled_uniqs: np.ndarray. Uniqs of the coarser pixels
             which are already filled.
@@ -307,6 +309,7 @@ def already_filled_uniqs_for_nside(
             already_filled_uniqs.append(uniq_original_nside)
     return np.array(already_filled_uniqs)
 
+
 def find_filled_pixels(uniqs: np.ndarray):
     """
     given an array of uniqs, finds which pixels already have finer
@@ -314,7 +317,7 @@ def find_filled_pixels(uniqs: np.ndarray):
 
     args:
         - uniqs: np.ndarray. Array of uniqs per each pixel of the map
-    
+
     returns:
         - already_filled_indeces: np.ndarray. Array with the indeces
             of the already_filled_uniqs in the input array
@@ -334,6 +337,7 @@ def find_filled_pixels(uniqs: np.ndarray):
     )
     return already_filled_indeces
 
+
 def clean_data_multiorder_map(
     grid_value: np.ndarray, uniqs: np.ndarray
 ):
@@ -345,7 +349,7 @@ def clean_data_multiorder_map(
             per each scanned pixel.
         - uniqs: np.ndarray. Uniqs per each scanned pixel to univocally
             identify them
-    
+
     returns:
         - grid_value: np.ndarray. Cleaned array
         - uniqs: np.ndarray. Cleaned array

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -100,29 +100,33 @@ def extract_map(
         # show 2 * delta_LLH
         grid_value = grid_value * 2.
         equatorial_map *= 2.
+
+        # nan values are a problem for the convolution and the contours
+        max_map = np.nanmax(equatorial_map)
+        equatorial_map[np.isnan(equatorial_map)] = max_map
     else:
         # Convert to probability
         equatorial_map = np.exp(-1. * equatorial_map)
         equatorial_map = equatorial_map / np.nansum(equatorial_map)
 
-    # nan values are a problem for the convolution and the contours
-    min_map = np.nanmin(equatorial_map)
-    equatorial_map[np.isnan(equatorial_map)] = min_map
-
-    if angular_error_floor is not None and not llh_map:
-        # convolute with a gaussian. angular_error_floor is the
-        # sigma in deg.
-        equatorial_map = healpy.smoothing(
-            equatorial_map,
-            sigma=np.deg2rad(angular_error_floor),
-        )
-
-        # normalize map
-        min_map = np.nanmin(equatorial_map[equatorial_map > 0.0])
+        # nan values are a problem for the convolution and the contours
+        min_map = np.nanmin(equatorial_map)
         equatorial_map[np.isnan(equatorial_map)] = min_map
-        equatorial_map = equatorial_map.clip(min_map, None)
-        normalization = np.nansum(equatorial_map)
-        equatorial_map = equatorial_map / normalization
+
+        if angular_error_floor is not None:
+            # convolute with a gaussian. angular_error_floor is the
+            # sigma in deg.
+            equatorial_map = healpy.smoothing(
+                equatorial_map,
+                sigma=np.deg2rad(angular_error_floor),
+            )
+
+            # normalize map
+            min_map = np.nanmin(equatorial_map[equatorial_map > 0.0])
+            equatorial_map[np.isnan(equatorial_map)] = min_map
+            equatorial_map = equatorial_map.clip(min_map, None)
+            normalization = np.nansum(equatorial_map)
+            equatorial_map = equatorial_map / normalization
 
         # obtain values for grid map
         grid_value = healpy.get_interp_val(

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -104,6 +104,8 @@ def extract_map(
         # nan values are a problem for the convolution and the contours
         max_map = np.nanmax(equatorial_map)
         equatorial_map[np.isnan(equatorial_map)] = max_map
+        grid_value[np.isnan(grid_value)] = max_map
+        grid_value = grid_value.clip(None, max_map)
     else:
         # Convert to probability
         equatorial_map = np.exp(-1. * equatorial_map)

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -74,8 +74,8 @@ def extract_map(
         
         if nside == nsides[0]:
             tot_npix = healpy.nside2npix(nside)
-            print(f"tot_npix: {tot_npix}\nlen(resuls_nside): {len(uniq_list)}")
-            if tot_npix < len(uniq_list):
+            print(f"tot_npix: {tot_npix}\nlen(resuls_nside): {len(results_nside)}")
+            if tot_npix > len(results_nside):
                 print(f"Filling nside {nside}")
                 ring_pixels = np.arange(tot_npix)
                 nest_pixels = healpy.ring2nest(nside, ring_pixels)

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -72,11 +72,11 @@ def extract_map(
             tmp_ra = tmp_phi
             grid_map[(tmp_dec, tmp_ra)] = value
         
+        # In case of pointed scans, it helps filling the first nside
+        # with empty pixels (especially for saving the multiorder map)
         if nside == nsides[0]:
             tot_npix = healpy.nside2npix(nside)
-            print(f"tot_npix: {tot_npix}\nlen(resuls_nside): {len(results_nside)}")
             if tot_npix > len(results_nside):
-                print(f"Filling nside {nside}")
                 ring_pixels = np.arange(tot_npix)
                 nest_pixels = healpy.ring2nest(nside, ring_pixels)
                 uniq_pixels = mhealpy.nest2uniq(nside, nest_pixels)

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -66,7 +66,6 @@ def extract_map(
             nested_pixel = healpy.ring2nest(nside, pixel)
             uniq = 4*nside*nside + nested_pixel
             uniq_list.append(uniq)
-            # if np.isfinite(value) and not np.isnan(value):
             tmp_theta, tmp_phi = healpy.pix2ang(nside, pixel)
             tmp_dec = np.pi/2 - tmp_theta
             tmp_ra = tmp_phi
@@ -113,12 +112,11 @@ def extract_map(
         grid_value = grid_value.clip(None, max_map)
     else:
         # Convert to probability
-        equatorial_map = np.exp(-1. * equatorial_map, dtype='float128')
+        equatorial_map = np.exp(-1. * equatorial_map)
         equatorial_map = equatorial_map / np.nansum(equatorial_map)
 
         # nan values are a problem for the convolution and the contours
         min_map = np.nanmin(equatorial_map[equatorial_map > 0.])
-        print(f"the minimum of the map is {min_map}")
         equatorial_map[np.isnan(equatorial_map)] = min_map
         equatorial_map[equatorial_map == 0.] = min_map
 

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -61,7 +61,7 @@ def extract_map(
             nested_pixel = healpy.ring2nest(nside, pixel)
             uniq = 4*nside*nside + nested_pixel
             uniq_list.append(uniq)
-            #if np.isfinite(value) and not np.isnan(value):
+            # if np.isfinite(value) and not np.isnan(value):
             tmp_theta, tmp_phi = healpy.pix2ang(nside, pixel)
             tmp_dec = np.pi/2 - tmp_theta
             tmp_ra = tmp_phi

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -71,20 +71,6 @@ def extract_map(
             tmp_dec = np.pi/2 - tmp_theta
             tmp_ra = tmp_phi
             grid_map[(tmp_dec, tmp_ra)] = value
-        
-        if nside == nsides[0]:
-            tot_npix = healpy.nside2npix(nside)
-            if tot_npix < len(results_nside):
-                ring_pixels = np.arange(tot_npix)
-                nest_pixels = healpy.ring2nest(nside, ring_pixels)
-                uniq_pixels = mhealpy.nest2uniq(nside, nest_pixels)
-                for uni, rin in zip(uniq_pixels, nest_pixels):
-                    if uni not in uniq_list:
-                        uniq_list.append(uni)
-                        tmp_theta, tmp_phi = healpy.pix2ang(nside, rin)
-                        tmp_dec = np.pi/2 - tmp_theta
-                        tmp_ra = tmp_phi
-                        grid_map[(tmp_dec, tmp_ra)] = np.nan
 
         LOGGER.info(f"done with map for nside {nside}...")
 

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -74,8 +74,8 @@ def extract_map(
         
         if nside == nsides[0]:
             tot_npix = healpy.nside2npix(nside)
-            print(f"tot_npix: {tot_npix}\nlen(resuls_nside): {len(results_nside)}")
-            if tot_npix < len(results_nside):
+            print(f"tot_npix: {tot_npix}\nlen(resuls_nside): {len(uniq_list)}")
+            if tot_npix < len(uniq_list):
                 print(f"Filling nside {nside}")
                 ring_pixels = np.arange(tot_npix)
                 nest_pixels = healpy.ring2nest(nside, ring_pixels)


### PR DESCRIPTION
With this pull request I would like to include in skyreader an implementation to save scans as multiorder maps.
The idea is to save exactly the same pixels as the ones which were scanned, and for each report the density of probability (or density of llh [deg-2] if a llh map is desired).

To do this, I needed to add some functions in `handle_map_data.py`, as for some directions there are multiple pixels scanned with different nsides. In these cases, the pixels with the bigger nside need to be ignored.

Moreover, I added some logic in `extract_map` to fill the bigger nside with empty pixels. This is necessary to produce multiorder maps for pointed scans as well. It does not cause problems in the rest of the processing as further on the empty pixels are filled with the smallest registered probability.

Happy to receive feedback about this!