### PR TITLE
Compatibility with lvk

### DIFF
--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -8,7 +8,7 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.13.0.34.51
+astropy-iers-data==0.2025.1.20.0.32.27
     # via astropy
 cachetools==5.5.0
     # via wipac-rest-tools
@@ -40,7 +40,7 @@ meander==0.0.3
     # via icecube-skyreader (setup.py)
 mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
-numpy==2.2.1
+numpy==2.2.2
     # via
     #   astropy
     #   contourpy

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -10,7 +10,7 @@ astropy==7.0.0
     #   icecube-skyreader (setup.py)
 astropy-iers-data==0.2025.1.20.0.32.27
     # via astropy
-cachetools==5.5.0
+cachetools==5.5.1
     # via wipac-rest-tools
 certifi==2024.12.14
     # via requests
@@ -24,7 +24,7 @@ cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.4
+fonttools==4.55.5
     # via matplotlib
 healpy==1.18.0
     # via
@@ -91,7 +91,7 @@ tornado==6.4.2
     # via wipac-rest-tools
 typing-extensions==4.12.2
     # via wipac-dev-tools
-tzdata==2024.2
+tzdata==2025.1
     # via pandas
 urllib3==2.3.0
     # via

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -24,7 +24,7 @@ cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.3
+fonttools==4.55.4
     # via matplotlib
 healpy==1.18.0
     # via

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -8,7 +8,7 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.6.0.33.42
+astropy-iers-data==0.2025.1.13.0.34.51
     # via astropy
 cachetools==5.5.0
     # via wipac-rest-tools
@@ -83,7 +83,7 @@ requests==2.32.3
     #   wipac-rest-tools
 requests-futures==1.0.2
     # via wipac-rest-tools
-scipy==1.15.0
+scipy==1.15.1
     # via icecube-skyreader (setup.py)
 six==1.17.0
     # via python-dateutil
@@ -97,7 +97,7 @@ urllib3==2.3.0
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.13.0
+wipac-dev-tools==1.15.0
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -8,15 +8,15 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.12.9.0.36.21
+astropy-iers-data==0.2025.1.6.0.33.42
     # via astropy
 cachetools==5.5.0
     # via wipac-rest-tools
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 contourpy==1.3.1
     # via matplotlib
@@ -32,15 +32,15 @@ healpy==1.18.0
     #   mhealpy
 idna==3.10
     # via requests
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via matplotlib
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
 mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
-numpy==2.2.0
+numpy==2.2.1
     # via
     #   astropy
     #   contourpy
@@ -56,7 +56,7 @@ packaging==24.2
     #   matplotlib
 pandas==2.2.3
     # via icecube-skyreader (setup.py)
-pillow==11.0.0
+pillow==11.1.0
     # via matplotlib
 pycparser==2.22
     # via cffi
@@ -64,7 +64,7 @@ pyerfa==2.0.1.5
     # via astropy
 pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
-pyparsing==3.2.0
+pyparsing==3.2.1
     # via matplotlib
 python-dateutil==2.9.0.post0
     # via
@@ -83,7 +83,7 @@ requests==2.32.3
     #   wipac-rest-tools
 requests-futures==1.0.2
     # via wipac-rest-tools
-scipy==1.14.1
+scipy==1.15.0
     # via icecube-skyreader (setup.py)
 six==1.17.0
     # via python-dateutil
@@ -93,7 +93,7 @@ typing-extensions==4.12.2
     # via wipac-dev-tools
 tzdata==2024.2
     # via pandas
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   wipac-rest-tools
@@ -101,5 +101,5 @@ wipac-dev-tools==1.13.0
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.8.4
+wipac-rest-tools==1.8.5
     # via icecube-skyreader (setup.py)

--- a/dependencies-examples.log
+++ b/dependencies-examples.log
@@ -8,11 +8,11 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.20.0.32.27
+astropy-iers-data==0.2025.2.3.0.32.42
     # via astropy
 cachetools==5.5.1
     # via wipac-rest-tools
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -24,7 +24,7 @@ cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.5
+fonttools==4.55.8
     # via matplotlib
 healpy==1.18.0
     # via
@@ -70,7 +70,7 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2024.2
+pytz==2025.1
     # via pandas
 pyyaml==6.0.2
     # via astropy
@@ -97,7 +97,7 @@ urllib3==2.3.0
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.15.0
+wipac-dev-tools==1.15.1
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -8,7 +8,7 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.6.0.33.42
+astropy-iers-data==0.2025.1.13.0.34.51
     # via astropy
 cachetools==5.5.0
     # via wipac-rest-tools
@@ -94,7 +94,7 @@ requests==2.32.3
     #   wipac-rest-tools
 requests-futures==1.0.2
     # via wipac-rest-tools
-scipy==1.15.0
+scipy==1.15.1
     # via icecube-skyreader (setup.py)
 six==1.17.0
     # via python-dateutil
@@ -108,7 +108,7 @@ urllib3==2.3.0
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.13.0
+wipac-dev-tools==1.15.0
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -24,7 +24,7 @@ cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.3
+fonttools==4.55.4
     # via matplotlib
 healpy==1.18.0
     # via

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -8,15 +8,15 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.12.9.0.36.21
+astropy-iers-data==0.2025.1.6.0.33.42
     # via astropy
 cachetools==5.5.0
     # via wipac-rest-tools
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 contourpy==1.3.1
     # via matplotlib
@@ -34,15 +34,15 @@ idna==3.10
     # via requests
 iniconfig==2.0.0
     # via pytest
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via matplotlib
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
 mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
-numpy==2.2.0
+numpy==2.2.1
     # via
     #   astropy
     #   contourpy
@@ -59,7 +59,7 @@ packaging==24.2
     #   pytest
 pandas==2.2.3
     # via icecube-skyreader (setup.py)
-pillow==11.0.0
+pillow==11.1.0
     # via matplotlib
 pluggy==1.5.0
     # via pytest
@@ -69,7 +69,7 @@ pyerfa==2.0.1.5
     # via astropy
 pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
-pyparsing==3.2.0
+pyparsing==3.2.1
     # via matplotlib
 pytest==8.3.4
     # via
@@ -94,7 +94,7 @@ requests==2.32.3
     #   wipac-rest-tools
 requests-futures==1.0.2
     # via wipac-rest-tools
-scipy==1.14.1
+scipy==1.15.0
     # via icecube-skyreader (setup.py)
 six==1.17.0
     # via python-dateutil
@@ -104,7 +104,7 @@ typing-extensions==4.12.2
     # via wipac-dev-tools
 tzdata==2024.2
     # via pandas
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   wipac-rest-tools
@@ -112,5 +112,5 @@ wipac-dev-tools==1.13.0
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools
-wipac-rest-tools==1.8.4
+wipac-rest-tools==1.8.5
     # via icecube-skyreader (setup.py)

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -10,7 +10,7 @@ astropy==7.0.0
     #   icecube-skyreader (setup.py)
 astropy-iers-data==0.2025.1.20.0.32.27
     # via astropy
-cachetools==5.5.0
+cachetools==5.5.1
     # via wipac-rest-tools
 certifi==2024.12.14
     # via requests
@@ -24,7 +24,7 @@ cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.4
+fonttools==4.55.5
     # via matplotlib
 healpy==1.18.0
     # via
@@ -102,7 +102,7 @@ tornado==6.4.2
     # via wipac-rest-tools
 typing-extensions==4.12.2
     # via wipac-dev-tools
-tzdata==2024.2
+tzdata==2025.1
     # via pandas
 urllib3==2.3.0
     # via

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -8,7 +8,7 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.13.0.34.51
+astropy-iers-data==0.2025.1.20.0.32.27
     # via astropy
 cachetools==5.5.0
     # via wipac-rest-tools
@@ -42,7 +42,7 @@ meander==0.0.3
     # via icecube-skyreader (setup.py)
 mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
-numpy==2.2.1
+numpy==2.2.2
     # via
     #   astropy
     #   contourpy

--- a/dependencies-mypy.log
+++ b/dependencies-mypy.log
@@ -8,11 +8,11 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.20.0.32.27
+astropy-iers-data==0.2025.2.3.0.32.42
     # via astropy
 cachetools==5.5.1
     # via wipac-rest-tools
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -24,7 +24,7 @@ cryptography==44.0.0
     # via pyjwt
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.5
+fonttools==4.55.8
     # via matplotlib
 healpy==1.18.0
     # via
@@ -81,7 +81,7 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2024.2
+pytz==2025.1
     # via pandas
 pyyaml==6.0.2
     # via astropy
@@ -108,7 +108,7 @@ urllib3==2.3.0
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.15.0
+wipac-dev-tools==1.15.1
     # via
     #   icecube-skyreader (setup.py)
     #   wipac-rest-tools

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -8,11 +8,11 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.12.9.0.36.21
+astropy-iers-data==0.2025.1.6.0.33.42
     # via astropy
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 contourpy==1.3.1
     # via matplotlib
@@ -28,15 +28,15 @@ idna==3.10
     # via requests
 iniconfig==2.0.0
     # via pytest
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via matplotlib
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
 mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
-numpy==2.2.0
+numpy==2.2.1
     # via
     #   astropy
     #   contourpy
@@ -53,13 +53,13 @@ packaging==24.2
     #   pytest
 pandas==2.2.3
     # via icecube-skyreader (setup.py)
-pillow==11.0.0
+pillow==11.1.0
     # via matplotlib
 pluggy==1.5.0
     # via pytest
 pyerfa==2.0.1.5
     # via astropy
-pyparsing==3.2.0
+pyparsing==3.2.1
     # via matplotlib
 pytest==8.3.4
     # via
@@ -77,7 +77,7 @@ pyyaml==6.0.2
     # via astropy
 requests==2.32.3
     # via wipac-dev-tools
-scipy==1.14.1
+scipy==1.15.0
     # via icecube-skyreader (setup.py)
 six==1.17.0
     # via python-dateutil
@@ -85,7 +85,7 @@ typing-extensions==4.12.2
     # via wipac-dev-tools
 tzdata==2024.2
     # via pandas
-urllib3==2.2.3
+urllib3==2.3.0
     # via requests
 wipac-dev-tools==1.13.0
     # via icecube-skyreader (setup.py)

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -8,9 +8,9 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.20.0.32.27
+astropy-iers-data==0.2025.2.3.0.32.42
     # via astropy
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
@@ -18,7 +18,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.5
+fonttools==4.55.8
     # via matplotlib
 healpy==1.18.0
     # via
@@ -71,7 +71,7 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2024.2
+pytz==2025.1
     # via pandas
 pyyaml==6.0.2
     # via astropy
@@ -87,5 +87,5 @@ tzdata==2025.1
     # via pandas
 urllib3==2.3.0
     # via requests
-wipac-dev-tools==1.15.0
+wipac-dev-tools==1.15.1
     # via icecube-skyreader (setup.py)

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -8,7 +8,7 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.6.0.33.42
+astropy-iers-data==0.2025.1.13.0.34.51
     # via astropy
 certifi==2024.12.14
     # via requests
@@ -77,7 +77,7 @@ pyyaml==6.0.2
     # via astropy
 requests==2.32.3
     # via wipac-dev-tools
-scipy==1.15.0
+scipy==1.15.1
     # via icecube-skyreader (setup.py)
 six==1.17.0
     # via python-dateutil
@@ -87,5 +87,5 @@ tzdata==2024.2
     # via pandas
 urllib3==2.3.0
     # via requests
-wipac-dev-tools==1.13.0
+wipac-dev-tools==1.15.0
     # via icecube-skyreader (setup.py)

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -18,7 +18,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.3
+fonttools==4.55.4
     # via matplotlib
 healpy==1.18.0
     # via

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -18,7 +18,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.4
+fonttools==4.55.5
     # via matplotlib
 healpy==1.18.0
     # via
@@ -83,7 +83,7 @@ six==1.17.0
     # via python-dateutil
 typing-extensions==4.12.2
     # via wipac-dev-tools
-tzdata==2024.2
+tzdata==2025.1
     # via pandas
 urllib3==2.3.0
     # via requests

--- a/dependencies-tests.log
+++ b/dependencies-tests.log
@@ -8,7 +8,7 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.13.0.34.51
+astropy-iers-data==0.2025.1.20.0.32.27
     # via astropy
 certifi==2024.12.14
     # via requests
@@ -36,7 +36,7 @@ meander==0.0.3
     # via icecube-skyreader (setup.py)
 mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
-numpy==2.2.1
+numpy==2.2.2
     # via
     #   astropy
     #   contourpy

--- a/dependencies.log
+++ b/dependencies.log
@@ -8,11 +8,11 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2024.12.9.0.36.21
+astropy-iers-data==0.2025.1.6.0.33.42
     # via astropy
-certifi==2024.8.30
+certifi==2024.12.14
     # via requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 contourpy==1.3.1
     # via matplotlib
@@ -26,15 +26,15 @@ healpy==1.18.0
     #   mhealpy
 idna==3.10
     # via requests
-kiwisolver==1.4.7
+kiwisolver==1.4.8
     # via matplotlib
-matplotlib==3.9.3
+matplotlib==3.10.0
     # via icecube-skyreader (setup.py)
 meander==0.0.3
     # via icecube-skyreader (setup.py)
 mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
-numpy==2.2.0
+numpy==2.2.1
     # via
     #   astropy
     #   contourpy
@@ -50,11 +50,11 @@ packaging==24.2
     #   matplotlib
 pandas==2.2.3
     # via icecube-skyreader (setup.py)
-pillow==11.0.0
+pillow==11.1.0
     # via matplotlib
 pyerfa==2.0.1.5
     # via astropy
-pyparsing==3.2.0
+pyparsing==3.2.1
     # via matplotlib
 python-dateutil==2.9.0.post0
     # via
@@ -66,7 +66,7 @@ pyyaml==6.0.2
     # via astropy
 requests==2.32.3
     # via wipac-dev-tools
-scipy==1.14.1
+scipy==1.15.0
     # via icecube-skyreader (setup.py)
 six==1.17.0
     # via python-dateutil
@@ -74,7 +74,7 @@ typing-extensions==4.12.2
     # via wipac-dev-tools
 tzdata==2024.2
     # via pandas
-urllib3==2.2.3
+urllib3==2.3.0
     # via requests
 wipac-dev-tools==1.13.0
     # via icecube-skyreader (setup.py)

--- a/dependencies.log
+++ b/dependencies.log
@@ -18,7 +18,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.3
+fonttools==4.55.4
     # via matplotlib
 healpy==1.18.0
     # via

--- a/dependencies.log
+++ b/dependencies.log
@@ -18,7 +18,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.4
+fonttools==4.55.5
     # via matplotlib
 healpy==1.18.0
     # via
@@ -72,7 +72,7 @@ six==1.17.0
     # via python-dateutil
 typing-extensions==4.12.2
     # via wipac-dev-tools
-tzdata==2024.2
+tzdata==2025.1
     # via pandas
 urllib3==2.3.0
     # via requests

--- a/dependencies.log
+++ b/dependencies.log
@@ -8,9 +8,9 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.20.0.32.27
+astropy-iers-data==0.2025.2.3.0.32.42
     # via astropy
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 charset-normalizer==3.4.1
     # via requests
@@ -18,7 +18,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.55.5
+fonttools==4.55.8
     # via matplotlib
 healpy==1.18.0
     # via
@@ -60,7 +60,7 @@ python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2024.2
+pytz==2025.1
     # via pandas
 pyyaml==6.0.2
     # via astropy
@@ -76,5 +76,5 @@ tzdata==2025.1
     # via pandas
 urllib3==2.3.0
     # via requests
-wipac-dev-tools==1.15.0
+wipac-dev-tools==1.15.1
     # via icecube-skyreader (setup.py)

--- a/dependencies.log
+++ b/dependencies.log
@@ -8,7 +8,7 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.13.0.34.51
+astropy-iers-data==0.2025.1.20.0.32.27
     # via astropy
 certifi==2024.12.14
     # via requests
@@ -34,7 +34,7 @@ meander==0.0.3
     # via icecube-skyreader (setup.py)
 mhealpy==0.3.4
     # via icecube-skyreader (setup.py)
-numpy==2.2.1
+numpy==2.2.2
     # via
     #   astropy
     #   contourpy

--- a/dependencies.log
+++ b/dependencies.log
@@ -8,7 +8,7 @@ astropy==7.0.0
     # via
     #   healpy
     #   icecube-skyreader (setup.py)
-astropy-iers-data==0.2025.1.6.0.33.42
+astropy-iers-data==0.2025.1.13.0.34.51
     # via astropy
 certifi==2024.12.14
     # via requests
@@ -66,7 +66,7 @@ pyyaml==6.0.2
     # via astropy
 requests==2.32.3
     # via wipac-dev-tools
-scipy==1.15.0
+scipy==1.15.1
     # via icecube-skyreader (setup.py)
 six==1.17.0
     # via python-dateutil
@@ -76,5 +76,5 @@ tzdata==2024.2
     # via pandas
 urllib3==2.3.0
     # via requests
-wipac-dev-tools==1.13.0
+wipac-dev-tools==1.15.0
     # via icecube-skyreader (setup.py)

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -812,7 +812,7 @@ class SkyScanPlotter:
         plt.legend(fontsize=6, loc="lower left")
 
         # save flattened map
-        equatorial_map, column_names = prepare_flattened_map(
+        equatorial_map, column_names, column_units = prepare_flattened_map(
             equatorial_map, llh_map
         )
         if llh_map:
@@ -822,14 +822,17 @@ class SkyScanPlotter:
         filename_main = f"{unique_id}.skymap_nside_{mmap_nside}_{type_map}"
         healpy.write_map(
             self.output_dir / f"{filename_main}.fits.gz",
-            equatorial_map,
+            equatorial_map / healpy.nside2pixarea(
+                max_nside, degrees=False,
+            ),
             coord='C',
             column_names=column_names,
+            column_units=column_units,
             extra_header=fits_header,
             overwrite=True
         )
-        multiorder_map, column_names = prepare_multiorder_map(
-            grid_value, uniq_array, llh_map, column_names
+        multiorder_map = prepare_multiorder_map(
+            grid_value, uniq_array, llh_map,
         )
         multiorder_map.write_map(
             self.output_dir / f"{filename_main}.multiorder.fits.gz",

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -132,8 +132,13 @@ class SkyScanPlotter:
                 plotting_map[plotting_map != 0.]
             )
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
+            equatorial_map[
+                np.logical_or(
+                    np.isnan(equatorial_map),
+                    equatorial_map == 0.
+                )
+            ] = 0.
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
-            equatorial_map[np.isnan(equatorial_map)] = 0.
             map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -133,13 +133,8 @@ class SkyScanPlotter:
             )
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
-            map_to_plot[plotting_map == 0.] = np.nan
-            map_to_plot[
-                np.logical_or(
-                    np.isnan(map_to_plot),
-                    map_to_plot == 0.
-                )
-            ] = np.nanmin(map_to_plot)
+            # map_to_plot[plotting_map == 0.] = np.nan
+            map_to_plot[np.isnan(map_to_plot)] = np.nanmin(map_to_plot)
         equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -699,6 +699,7 @@ class SkyScanPlotter:
         else:
             type_map = "probability"
         filename_main = f"{unique_id}.skymap_nside_{mmap_nside}_{type_map}"
+        print(equatorial_map)
         healpy.write_map(
             self.output_dir / f"{filename_main}.fits.gz",
             equatorial_map,

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -706,7 +706,8 @@ class SkyScanPlotter:
             coord='C',
             column_names=column_names,
             extra_header=fits_header,
-            overwrite=True
+            overwrite=True,
+            dtype='float32'
         )
         multiorder_map, column_names = prepare_multiorder_map(
             grid_value, uniq_array, llh_map, column_names

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -132,14 +132,14 @@ class SkyScanPlotter:
                 plotting_map[plotting_map != 0.]
             )
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
+            print(np.min(equatorial_map), np.nanmin(equatorial_map))
+            map_to_plot[plotting_map == 0.] = np.nan
             map_to_plot[
                 np.logical_or(
                     np.isnan(map_to_plot),
                     map_to_plot == 0.
                 )
             ] = np.nanmin(map_to_plot)
-            print(np.min(equatorial_map), np.nanmin(equatorial_map))
-            map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -184,7 +184,7 @@ class SkyScanPlotter:
             contour_set = ax.contour(
                 ra, dec, map_to_plot, levels=[level], colors=[color]
             )
-            print(contour_set)
+            print(contour_set.get_paths())
             cs_collections.append(contour_set.get_paths()[0])
             print(level, cs_collections)
             e, _ = contour_set.legend_elements()

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -686,7 +686,7 @@ class SkyScanPlotter:
         plt.legend(fontsize=6, loc="lower left")
 
         # save flattened map
-        equatorial_map, column_names = prepare_flattened_map(
+        equatorial_map, column_names, column_units = prepare_flattened_map(
             equatorial_map, llh_map
         )
         if llh_map:
@@ -699,7 +699,7 @@ class SkyScanPlotter:
             equatorial_map,
             coord='C',
             column_names=column_names,
-            column_units=["pix-1"],
+            column_units=column_units,
             extra_header=fits_header,
             overwrite=True,
         )

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -132,10 +132,10 @@ class SkyScanPlotter:
                 plotting_map[plotting_map != 0.]
             )
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
-            equatorial_map[
+            map_to_plot[
                 np.logical_or(
-                    np.isnan(equatorial_map),
-                    equatorial_map == 0.
+                    np.isnan(map_to_plot),
+                    map_to_plot == 0.
                 )
             ] = np.nanmin(equatorial_map[equatorial_map > 0.])
             print(np.min(equatorial_map), np.nanmin(equatorial_map))

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -140,7 +140,7 @@ class SkyScanPlotter:
             ] = np.nanmin(equatorial_map[equatorial_map > 0.])
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
             map_to_plot[plotting_map == 0.] = np.nan
-        # equatorial_map = np.ma.masked_invalid(equatorial_map)
+        equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)
 
         LOGGER.info(f"Preparing plot: {plot_filename}...")
@@ -185,6 +185,7 @@ class SkyScanPlotter:
                 ra, dec, map_to_plot, levels=[level], colors=[color]
             )
             cs_collections.append(contour_set.get_paths()[0])
+            print(cs_collections)
             e, _ = contour_set.legend_elements()
             leg_element.append(e[0])
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -168,15 +168,12 @@ class SkyScanPlotter:
             contour_levels, contour_labels, contour_colors
         ) = get_contour_levels(equatorial_map, llh_map, systematics)
 
-        leg_element = []
         for level, color in zip(contour_levels, contour_colors):
             if not llh_map:
                 level = np.log10(level)
-            contour_set = ax.contour(
+            ax.contour(
                 ra, dec, map_to_plot, levels=[level], colors=[color]
             )
-            e, _ = contour_set.legend_elements()
-            leg_element.append(e[0])
 
         # graticule
         if isinstance(ax, AstroMollweideAxes):

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -131,6 +131,7 @@ class SkyScanPlotter:
             map_to_plot[plotting_map != 0.] = np.log10(
                 plotting_map[plotting_map != 0.]
             )
+            print(f"max equatorial map: {np.nanmax(equatorial_map)}")
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
             # map_to_plot[plotting_map == 0.] = np.nan

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -185,7 +185,7 @@ class SkyScanPlotter:
                 ra, dec, map_to_plot, levels=[level], colors=[color]
             )
             cs_collections.append(contour_set.get_paths()[0])
-            print(cs_collections)
+            print(level, cs_collections)
             e, _ = contour_set.legend_elements()
             leg_element.append(e[0])
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -221,7 +221,7 @@ class SkyScanPlotter:
 
             leg_labels = []
             for i in range(len(contour_labels)):
-                vs = cs_collections[i].get_paths()[0].vertices
+                vs = cs_collections[i].vertices
                 # Compute area enclosed by vertices.
                 # Take absolute values to be independent of orientation of
                 # the boundary integral.

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -21,7 +21,6 @@ from matplotlib.projections import projection_registry  # type: ignore[import]
 
 from .plotting_tools import (
     AstroMollweideAxes,
-    DecFormatter,
     format_fits_header,
     hp_ticklabels,
     plot_catalog
@@ -102,8 +101,6 @@ class SkyScanPlotter:
         grid_pix = healpy.ang2pix(max(nsides), np.pi/2. - DEC, RA)
         plotting_map = equatorial_map[grid_pix]
 
-        min_value = grid_value[0]  # for probability map, this is actually
-        # the max_value
         min_dec = grid_dec[0]
         min_ra = grid_ra[0]
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -169,14 +169,12 @@ class SkyScanPlotter:
         ) = get_contour_levels(equatorial_map, llh_map, systematics)
 
         leg_element = []
-        cs_collections = []
         for level, color in zip(contour_levels, contour_colors):
             if not llh_map:
                 level = np.log10(level)
             contour_set = ax.contour(
                 ra, dec, map_to_plot, levels=[level], colors=[color]
             )
-            cs_collections.append(contour_set.get_paths()[0])
             e, _ = contour_set.legend_elements()
             leg_element.append(e[0])
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -756,6 +756,7 @@ class SkyScanPlotter:
             )
 
         uncertainty = [(ra_minus, ra_plus), (dec_minus, dec_plus)]
+        print(event_metadata)
         fits_header = format_fits_header(
             (
                 event_metadata.run_id,

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -756,7 +756,6 @@ class SkyScanPlotter:
             )
 
         uncertainty = [(ra_minus, ra_plus), (dec_minus, dec_plus)]
-        print(event_metadata)
         fits_header = format_fits_header(
             (
                 event_metadata.run_id,

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -137,7 +137,7 @@ class SkyScanPlotter:
                     np.isnan(map_to_plot),
                     map_to_plot == 0.
                 )
-            ] = np.nanmin(equatorial_map[equatorial_map > 0.])
+            ] = np.nanmin(map_to_plot[map_to_plot > 0.])
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
             map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -133,7 +133,7 @@ class SkyScanPlotter:
             )
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
-            # map_to_plot[plotting_map == 0.] = np.nan
+            map_to_plot[plotting_map == 0.] = np.nan
             map_to_plot[
                 np.logical_or(
                     np.isnan(map_to_plot),
@@ -184,6 +184,7 @@ class SkyScanPlotter:
             contour_set = ax.contour(
                 ra, dec, map_to_plot, levels=[level], colors=[color]
             )
+            print(contour_set)
             cs_collections.append(contour_set.get_paths()[0])
             print(level, cs_collections)
             e, _ = contour_set.legend_elements()

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -133,7 +133,7 @@ class SkyScanPlotter:
             )
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
-            map_to_plot[plotting_map == 0.] = np.nan
+            # map_to_plot[plotting_map == 0.] = np.nan
             map_to_plot[
                 np.logical_or(
                     np.isnan(map_to_plot),

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -133,6 +133,7 @@ class SkyScanPlotter:
             )
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
+            equatorial_map[np.isnan(equatorial_map)] = 0.
             map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -704,6 +704,7 @@ class SkyScanPlotter:
             equatorial_map,
             coord='C',
             column_names=column_names,
+            column_units=["pix-1"]
             extra_header=fits_header,
             overwrite=True,
         )

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -41,7 +41,7 @@ LOGGER = logging.getLogger("skyreader.plot")
 class SkyScanPlotter:
     PLOT_SIZE_Y_IN: float = 3.85
     PLOT_SIZE_X_IN: float = 6
-    PLOT_DPI_STANDARD = 150
+    PLOT_DPI_STANDARD = 300
     PLOT_DPI_ZOOMED = 1200
     PLOT_COLORMAP = matplotlib.colormaps['plasma_r']
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -134,10 +134,10 @@ class SkyScanPlotter:
             print(f"max equatorial map: {np.nanmax(equatorial_map)}")
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
-            # map_to_plot[plotting_map == 0.] = np.nan
+            map_to_plot[plotting_map == 0.] = np.nan
             map_to_plot[np.isnan(map_to_plot)] = np.nanmin(map_to_plot)
         equatorial_map = np.ma.masked_invalid(equatorial_map)
-        map_to_plot = np.ma.masked_invalid(map_to_plot)
+        # map_to_plot = np.ma.masked_invalid(map_to_plot)
 
         LOGGER.info(f"Preparing plot: {plot_filename}...")
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -131,7 +131,8 @@ class SkyScanPlotter:
             map_to_plot[plotting_map != 0.] = np.log10(
                 plotting_map[plotting_map != 0.]
             )
-            #map_to_plot[plotting_map == 0.] = np.nan
+            print(np.min(map_to_plot), np.nanmin(map_to_plot))
+            map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -55,7 +55,6 @@ class SkyScanPlotter:
     def create_plot(
         self,
         result: SkyScanResult,
-        dozoom: bool = False,
         systematics: bool = False,
         llh_map: bool = True,
         angular_error_floor: Union[None, float] = None,
@@ -65,7 +64,7 @@ class SkyScanPlotter:
         PLOT_DPI_STANDARD and PLOT_DPI_ZOOMED. Zoomed mode is very inefficient
         as the meshgrid is created for the full sky.
         """
-        dpi = self.PLOT_DPI_STANDARD if not dozoom else self.PLOT_DPI_ZOOMED
+        dpi = self.PLOT_DPI_STANDARD
 
         # number of  grid points along RA coordinate
         xsize = int(self.PLOT_SIZE_X_IN * dpi)
@@ -90,11 +89,7 @@ class SkyScanPlotter:
         mjd_str = f"MJD: {event_metadata.mjd}"
         plot_title = f"{run_str} {evt_str} {typ_str} {mjd_str}"
 
-        if dozoom:
-            addition_to_filename = 'plot_zoomed_legacy.'
-        else:
-            addition_to_filename = ''
-        plot_filename = f"{unique_id}.{addition_to_filename}pdf"
+        plot_filename = f"{unique_id}.pdf"
         LOGGER.info(f"saving plot to {plot_filename}")
 
         grid_value, grid_ra, grid_dec, equatorial_map, _ = extract_map(
@@ -118,12 +113,6 @@ class SkyScanPlotter:
         LOGGER.info(f"min Dec: {min_dec * 180./np.pi} deg")
 
         # renormalize
-        if dozoom:
-            plotting_map = plotting_map - min_value
-            equatorial_map = equatorial_map - min_value
-            vmin = 0.
-            vmax = 50
-            map_to_plot = plotting_map
         if llh_map:
             cmap = self.PLOT_COLORMAP
             text_colorbar = r"$-2 \ln(L)$"
@@ -162,11 +151,8 @@ class SkyScanPlotter:
 
         ax = None
 
-        if dozoom:
-            ax = fig.add_subplot(111)  # ,projection='cartesian')
-        else:
-            cmap.set_over(alpha=0.)  # make underflows transparent
-            ax = fig.add_subplot(111, projection='astro mollweide')
+        cmap.set_over(alpha=0.)  # make underflows transparent
+        ax = fig.add_subplot(111, projection='astro mollweide')
 
         # rasterized makes the map bitmap while the labels remain vectorial
         # flip longitude to the astro convention
@@ -197,112 +183,19 @@ class SkyScanPlotter:
             e, _ = contour_set.legend_elements()
             leg_element.append(e[0])
 
-        if not dozoom:
-            # graticule
-            if isinstance(ax, AstroMollweideAxes):
-                # mypy guard
-                ax.set_longitude_grid(30)
-                ax.set_latitude_grid(30)
-            cb = fig.colorbar(
-                image,
-                orientation='horizontal',
-                shrink=.6,
-                pad=0.05,
-                ticks=[vmin, vmax],
-            )
-            cb.ax.xaxis.set_label_text(text_colorbar)
-        else:
-            ax.set_xlabel('right ascension')
-            ax.set_ylabel('declination')
-            cb = fig.colorbar(
-                image, orientation='horizontal', shrink=.6, pad=0.13
-            )
-            cb.ax.xaxis.set_label_text(r"$-2 \Delta \ln (L)$")
-
-            leg_labels = []
-            for i in range(len(contour_labels)):
-                vs = cs_collections[i].vertices
-                # Compute area enclosed by vertices.
-                # Take absolute values to be independent of orientation of
-                # the boundary integral.
-                contour_area = abs(calculate_area(vs))  # in square-radians
-                # convert to square-degrees
-                contour_area_sqdeg = contour_area*(180.*180.)/(np.pi*np.pi)
-
-                area_string = f"area: {contour_area_sqdeg:.2f}sqdeg"
-                leg_labels.append(
-                    f'{contour_labels[i]} - {area_string}'
-                )
-
-            ax.scatter(
-                min_ra,
-                min_dec,
-                s=20,
-                marker='*',
-                color='black',
-                label=r'scan best-fit',
-                zorder=2
-            )
-            ax.legend(
-                leg_element,
-                leg_labels,
-                loc='lower right',
-                fontsize=8,
-                scatterpoints=1,
-                ncol=2
-            )
-
-            LOGGER.info(f"Contour Area (90%): {contour_area_sqdeg} "
-                        f"degrees (cartesian) "
-                        f"{contour_area_sqdeg * np.cos(min_dec)**2} "
-                        "degrees (scaled)")
-            x_width = 1.6 * np.sqrt(contour_area_sqdeg)
-            LOGGER.info(f"x width is {x_width}")
-            if np.isnan(x_width):
-                # this get called only when contour_area / x_width is
-                # NaN so possibly never invoked in typical situations
-                raise RuntimeError(
-                    "Estimated area / width is NaN and the fallback logic "
-                    "for this scenario is no longer supported. If you "
-                    "encounter this error raise an issue to SkyReader."
-                )
-                # mypy error: "QuadContourSet" has no attribute "allsegs"
-                # [attr-defined]. This attribute is likely deprecated but
-                # this scenario is rarely (if ever) hit original code is
-                # kept commented for the time being
-
-                # note: contour_set is re-assigned at every iteration of
-                # the loop on contour_levels, contour_colors, so this
-                # effectively corresponds to the last contour_set
-                # x_width = 1.6*(max(contour_set.allsegs[i][0][:,0]) -
-                # min(contour_set.allsegs[i][0][:,0]))
-
-            y_width = 0.5 * x_width
-
-            lower_x = max(min_ra - x_width*np.pi/180., 0.)
-            upper_x = min(min_ra + x_width*np.pi/180., 2 * np.pi)
-            lower_y = max(min_dec - y_width*np.pi/180., -np.pi/2.)
-            upper_y = min(min_dec + y_width*np.pi/180., np.pi/2.)
-
-            ax.set_xlim(upper_x, lower_x)
-            ax.set_ylim(lower_y, upper_y)
-
-            # why not RAFormatter?
-            ax.xaxis.set_major_formatter(DecFormatter())
-
-            ax.yaxis.set_major_formatter(DecFormatter())
-
-            factor = 0.25*(np.pi/180.)
-            while (upper_x - lower_x)/factor > 6:
-                factor *= 2.
-            tick_label_grid = factor
-
-            ax.xaxis.set_major_locator(
-                matplotlib.ticker.MultipleLocator(base=tick_label_grid)
-            )
-            ax.yaxis.set_major_locator(
-                matplotlib.ticker.MultipleLocator(base=tick_label_grid)
-            )
+        # graticule
+        if isinstance(ax, AstroMollweideAxes):
+            # mypy guard
+            ax.set_longitude_grid(30)
+            ax.set_latitude_grid(30)
+        cb = fig.colorbar(
+            image,
+            orientation='horizontal',
+            shrink=.6,
+            pad=0.05,
+            ticks=[vmin, vmax],
+        )
+        cb.ax.xaxis.set_label_text(text_colorbar)
 
         # cb.ax.xaxis.labelpad = -8
         # workaround for issue with viewers, see colorbar docstring
@@ -310,9 +203,6 @@ class SkyScanPlotter:
         # it is actually a valid object before accessing it
         if isinstance(cb.solids, matplotlib.collections.QuadMesh):
             cb.solids.set_edgecolor("face")
-
-        if dozoom:
-            ax.set_aspect('equal')
 
         ax.tick_params(axis='x', labelsize=10)
         ax.tick_params(axis='y', labelsize=10)
@@ -333,20 +223,12 @@ class SkyScanPlotter:
 
         # remove white space around figure
         spacing = 0.01
-        if not dozoom:
-            fig.subplots_adjust(
-                bottom=spacing,
-                top=1.-spacing,
-                left=spacing+0.04,
-                right=1.-spacing
-            )
-        else:
-            fig.subplots_adjust(
-                bottom=spacing,
-                top=0.92-spacing,
-                left=spacing+0.1,
-                right=1.-spacing
-            )
+        fig.subplots_adjust(
+            bottom=spacing,
+            top=1.-spacing,
+            left=spacing+0.04,
+            right=1.-spacing
+        )
 
         # set the title
         fig.suptitle(plot_title)

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -131,7 +131,7 @@ class SkyScanPlotter:
             map_to_plot[plotting_map != 0.] = np.log10(
                 plotting_map[plotting_map != 0.]
             )
-            map_to_plot[plotting_map == 0.] = np.nan
+            #map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -193,7 +193,7 @@ class SkyScanPlotter:
             contour_set = ax.contour(
                 ra, dec, map_to_plot, levels=[level], colors=[color]
             )
-            cs_collections.append(contour_set.collections[0])
+            cs_collections.append(contour_set.get_paths()[0])
             e, _ = contour_set.legend_elements()
             leg_element.append(e[0])
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -691,7 +691,7 @@ class SkyScanPlotter:
         plt.legend(fontsize=6, loc="lower left")
 
         # save flattened map
-        equatorial_map, column_names, column_units = prepare_flattened_map(
+        equatorial_map, column_names = prepare_flattened_map(
             equatorial_map, llh_map
         )
         if llh_map:
@@ -701,17 +701,14 @@ class SkyScanPlotter:
         filename_main = f"{unique_id}.skymap_nside_{mmap_nside}_{type_map}"
         healpy.write_map(
             self.output_dir / f"{filename_main}.fits.gz",
-            equatorial_map / healpy.nside2pixarea(
-                max_nside, degrees=False,
-            ),
+            equatorial_map,
             coord='C',
             column_names=column_names,
-            column_units=column_units,
             extra_header=fits_header,
             overwrite=True
         )
-        multiorder_map = prepare_multiorder_map(
-            grid_value, uniq_array, llh_map,
+        multiorder_map, column_names = prepare_multiorder_map(
+            grid_value, uniq_array, llh_map, column_names
         )
         multiorder_map.write_map(
             self.output_dir / f"{filename_main}.multiorder.fits.gz",

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -132,6 +132,7 @@ class SkyScanPlotter:
                 plotting_map[plotting_map != 0.]
             )
             print(np.min(map_to_plot), np.nanmin(map_to_plot))
+            print(np.min(equatorial_map), np.nanmin(equatorial_map))
             map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -132,12 +132,12 @@ class SkyScanPlotter:
                 plotting_map[plotting_map != 0.]
             )
             print(f"max equatorial map: {np.nanmax(equatorial_map)}")
-            print(np.min(map_to_plot), np.nanmin(map_to_plot))
+            print(np.min(map_to_plot), np.nanmin(map_to_plot), np.nanmax(map_to_plot))
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
             map_to_plot[plotting_map == 0.] = np.nan
             map_to_plot[np.isnan(map_to_plot)] = np.nanmin(map_to_plot)
         equatorial_map = np.ma.masked_invalid(equatorial_map)
-        # map_to_plot = np.ma.masked_invalid(map_to_plot)
+        map_to_plot = np.ma.masked_invalid(map_to_plot)
 
         LOGGER.info(f"Preparing plot: {plot_filename}...")
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -131,11 +131,7 @@ class SkyScanPlotter:
             map_to_plot[plotting_map != 0.] = np.log10(
                 plotting_map[plotting_map != 0.]
             )
-            print(f"max equatorial map: {np.nanmax(equatorial_map)}")
-            print(np.min(map_to_plot), np.nanmin(map_to_plot), np.nanmax(map_to_plot))
-            print(np.min(equatorial_map), np.nanmin(equatorial_map))
             map_to_plot[plotting_map == 0.] = np.nan
-            map_to_plot[np.isnan(map_to_plot)] = np.nanmin(map_to_plot)
         equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)
 
@@ -180,9 +176,7 @@ class SkyScanPlotter:
             contour_set = ax.contour(
                 ra, dec, map_to_plot, levels=[level], colors=[color]
             )
-            print(contour_set.get_paths())
             cs_collections.append(contour_set.get_paths()[0])
-            print(level, cs_collections)
             e, _ = contour_set.legend_elements()
             leg_element.append(e[0])
 

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -699,7 +699,6 @@ class SkyScanPlotter:
         else:
             type_map = "probability"
         filename_main = f"{unique_id}.skymap_nside_{mmap_nside}_{type_map}"
-        print(equatorial_map)
         healpy.write_map(
             self.output_dir / f"{filename_main}.fits.gz",
             equatorial_map,
@@ -707,7 +706,6 @@ class SkyScanPlotter:
             column_names=column_names,
             extra_header=fits_header,
             overwrite=True,
-            #dtype='float32'
         )
         multiorder_map, column_names = prepare_multiorder_map(
             grid_value, uniq_array, llh_map, column_names

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -707,7 +707,7 @@ class SkyScanPlotter:
             column_names=column_names,
             extra_header=fits_header,
             overwrite=True,
-            dtype='float32'
+            #dtype='float32'
         )
         multiorder_map, column_names = prepare_multiorder_map(
             grid_value, uniq_array, llh_map, column_names

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -137,7 +137,7 @@ class SkyScanPlotter:
                     np.isnan(map_to_plot),
                     map_to_plot == 0.
                 )
-            ] = np.nanmin(map_to_plot[map_to_plot > 0.])
+            ] = np.nanmin(map_to_plot)
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
             map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -137,7 +137,7 @@ class SkyScanPlotter:
                     np.isnan(equatorial_map),
                     equatorial_map == 0.
                 )
-            ] = 0.
+            ] = np.nanmin(equatorial_map[equatorial_map > 0.])
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
             map_to_plot[plotting_map == 0.] = np.nan
         equatorial_map = np.ma.masked_invalid(equatorial_map)

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -704,7 +704,7 @@ class SkyScanPlotter:
             equatorial_map,
             coord='C',
             column_names=column_names,
-            column_units=["pix-1"]
+            column_units=["pix-1"],
             extra_header=fits_header,
             overwrite=True,
         )

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -140,7 +140,7 @@ class SkyScanPlotter:
             ] = np.nanmin(equatorial_map[equatorial_map > 0.])
             print(np.min(equatorial_map), np.nanmin(equatorial_map))
             map_to_plot[plotting_map == 0.] = np.nan
-        equatorial_map = np.ma.masked_invalid(equatorial_map)
+        # equatorial_map = np.ma.masked_invalid(equatorial_map)
         map_to_plot = np.ma.masked_invalid(map_to_plot)
 
         LOGGER.info(f"Preparing plot: {plot_filename}...")

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -35,7 +35,7 @@ def format_fits_header(
         ('RUNID', run_id),
         ('EVENTID', event_id),
         ('SENDER', 'IceCube Collaboration'),
-        ('DATE-OBS', t.isot, 'UTC date of the observation')
+        ('DATE-OBS', t.isot, 'UTC date of the observation'),
         ('MJD-OBS', mjd, 'modified Julian date of the observation'),
         ('I3TYPE', f'{event_type}','Alert Type'),
         ('RA', np.round(ra,2),'Degree'),

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -32,7 +32,8 @@ def format_fits_header(
         ('RUNID', run_id),
         ('EVENTID', event_id),
         ('SENDER', 'IceCube Collaboration'),
-        ('EventMJD', mjd),
+        # ('DATE-OBS', )
+        ('MJD-OBS', mjd, 'modified Julian date of observation'),
         ('I3TYPE', f'{event_type}','Alert Type'),
         ('RA', np.round(ra,2),'Degree'),
         ('DEC', np.round(dec,2),'Degree'),

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -4,6 +4,7 @@
 # flake8: noqa
 
 import astropy.io.fits as pyfits  # type: ignore[import]
+from astropy.time import Time  # type: ignore[import]
 import healpy  # type: ignore[import]
 import matplotlib  # type: ignore[import]
 import matplotlib.patheffects as path_effects  # type: ignore[import]
@@ -28,12 +29,14 @@ def format_fits_header(
     else:
         uncertainty_comment = 'Highest posterior density 90% credible region'
 
+    t = Time(mjd, format="mjd")
+
     header = [
         ('RUNID', run_id),
         ('EVENTID', event_id),
         ('SENDER', 'IceCube Collaboration'),
-        # ('DATE-OBS', )
-        ('MJD-OBS', mjd, 'modified Julian date of observation'),
+        ('DATE-OBS', t.isot, 'UTC date of the observation')
+        ('MJD-OBS', mjd, 'modified Julian date of the observation'),
         ('I3TYPE', f'{event_type}','Alert Type'),
         ('RA', np.round(ra,2),'Degree'),
         ('DEC', np.round(dec,2),'Degree'),

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -400,8 +400,10 @@ def prepare_multiorder_map(
         max_nside = np.max(all_nsides)
         multiorder_map = mhealpy.HealpixMap(
             grid_value / healpy.nside2pixarea(
-                max_nside, degrees=True,
-            ), uniq_array
+                max_nside, degrees=False,
+            ),
+            uniq_array,
+            unit = "sr-1"
         )
-        column_names = [f"{column_names[0]} DENSITY [deg-2]"]
+        column_names = ["PROBDENSITY"]
     return multiorder_map, column_names

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -362,20 +362,22 @@ def clean_data_multiorder_map(
 def prepare_flattened_map(
     equatorial_map: np.ndarray,
     llh_map: bool,
-) -> Tuple[np.ndarray, List[str]]:
+) -> Tuple[np.ndarray, List[str], List[str]]:
     """
     Create the healpix map that needs to be saved keeping
     into account if it is a probability or a llh map
     """
     if llh_map:
         column_names = ['2DLLH']
+        column_units = None
     else:
         # avoid excessively heavy data format for the flattened map
         equatorial_map[equatorial_map < 1e-16] = np.nanmean(
             equatorial_map[equatorial_map < 1e-16]
         )
         column_names = ["PROB"]
-    return equatorial_map, column_names
+        column_units = ["pix-1"]
+    return equatorial_map, column_names, column_units
 
 
 def prepare_multiorder_map(

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -369,20 +369,21 @@ def prepare_flattened_map(
     """
     if llh_map:
         column_names = ['2DLLH']
+        column_units = None
     else:
         # avoid excessively heavy data format for the flattened map
         equatorial_map[equatorial_map < 1e-16] = np.nanmean(
             equatorial_map[equatorial_map < 1e-16]
         )
-        column_names = ["PROBABILITY"]
-    return equatorial_map, column_names
+        column_names = ["PROBDENSITY"]
+        column_units = ["sr-1"]
+    return equatorial_map, column_names, column_units
 
 
 def prepare_multiorder_map(
     grid_value: np.ndarray,
     uniq_array: np.ndarray,
     llh_map: bool,
-    column_names: List[str]
 ) -> Tuple[mhealpy.HealpixMap, List[str]]:
     """
     Create the mhealpix map that needs to be saved keeping
@@ -405,5 +406,4 @@ def prepare_multiorder_map(
             uniq_array,
             unit="sr-1"
         )
-        column_names = ["PROBDENSITY"]
-    return multiorder_map, column_names
+    return multiorder_map

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -384,7 +384,7 @@ def prepare_multiorder_map(
     grid_value: np.ndarray,
     uniq_array: np.ndarray,
     llh_map: bool,
-) -> Tuple[mhealpy.HealpixMap, List[str]]:
+) -> mhealpy.HealpixMap:
     """
     Create the mhealpix map that needs to be saved keeping
     into account if it is a probability or a llh map

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -374,7 +374,7 @@ def prepare_flattened_map(
         equatorial_map[equatorial_map < 1e-16] = np.nanmean(
             equatorial_map[equatorial_map < 1e-16]
         )
-        column_names = ["PROBABILITY"]
+        column_names = ["PROB"]
     return equatorial_map, column_names
 
 

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -362,7 +362,7 @@ def clean_data_multiorder_map(
 def prepare_flattened_map(
     equatorial_map: np.ndarray,
     llh_map: bool,
-) -> Tuple[np.ndarray, List[str], Union[List[str], None]]:
+) -> Tuple[np.ndarray, List[str]]:
     """
     Create the healpix map that needs to be saved keeping
     into account if it is a probability or a llh map
@@ -383,7 +383,7 @@ def prepare_multiorder_map(
     uniq_array: np.ndarray,
     llh_map: bool,
     column_names: List[str]
-) -> mhealpy.HealpixMap:
+) -> Tuple[mhealpy.HealpixMap, List[str]]:
     """
     Create the mhealpix map that needs to be saved keeping
     into account if it is a probability or a llh map

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -369,21 +369,20 @@ def prepare_flattened_map(
     """
     if llh_map:
         column_names = ['2DLLH']
-        column_units = None
     else:
         # avoid excessively heavy data format for the flattened map
         equatorial_map[equatorial_map < 1e-16] = np.nanmean(
             equatorial_map[equatorial_map < 1e-16]
         )
-        column_names = ["PROBDENSITY"]
-        column_units = ["sr-1"]
-    return equatorial_map, column_names, column_units
+        column_names = ["PROBABILITY"]
+    return equatorial_map, column_names
 
 
 def prepare_multiorder_map(
     grid_value: np.ndarray,
     uniq_array: np.ndarray,
     llh_map: bool,
+    column_names: List[str]
 ) -> mhealpy.HealpixMap:
     """
     Create the mhealpix map that needs to be saved keeping
@@ -406,4 +405,5 @@ def prepare_multiorder_map(
             uniq_array,
             unit="sr-1"
         )
-    return multiorder_map
+        column_names = ["PROBDENSITY"]
+    return multiorder_map, column_names

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -362,7 +362,7 @@ def clean_data_multiorder_map(
 def prepare_flattened_map(
     equatorial_map: np.ndarray,
     llh_map: bool,
-) -> Tuple[np.ndarray, List[str], List[str]]:
+) -> Tuple[np.ndarray, List[str], Union[List[str], None]]:
     """
     Create the healpix map that needs to be saved keeping
     into account if it is a probability or a llh map

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -362,7 +362,7 @@ def clean_data_multiorder_map(
 def prepare_flattened_map(
     equatorial_map: np.ndarray,
     llh_map: bool,
-) -> Tuple[np.ndarray, List[str]]:
+) -> Tuple[np.ndarray, List[str], Union[List[str], None]]:
     """
     Create the healpix map that needs to be saved keeping
     into account if it is a probability or a llh map

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -403,7 +403,7 @@ def prepare_multiorder_map(
                 max_nside, degrees=False,
             ),
             uniq_array,
-            unit = "sr-1"
+            unit="sr-1"
         )
         column_names = ["PROBDENSITY"]
     return multiorder_map, column_names


### PR DESCRIPTION
To be more compatible with LVK, I:
- Changed the unit in the multiorder maps from deg-2 to sr-1;
- The unit is stored now in `TUNIT2` in the header;
- Changed the column name from `PROBABILITY DENSITY [deg-2]` to `[PROBDENSITY]`.

Moreover, in `plot.py` there were problems bacause the new matplotlib doesn't support anymore the attribute `QuadContourSet.collections`. This affects only `create_plot` when `dozoom` is set to `True`. I tried by using `get_paths()` to fix the problem, but I am not totally sure it is really doing what it should. At least in general it is not anymore giving error. However, is the option `dozoom=True` still used? It seems to me only redundant because there is already `create_plot_zoomed`. Could we get rid of the option `dozoom=True`?