### PR TITLE
[minor] Fix pixel ordering and selection of best-fit direction

### DIFF
--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -138,6 +138,12 @@ def extract_map(
         )
         grid_value = grid_value.clip(min_map, None)
 
+        sorting_indices = np.argsort(-grid_value)
+        grid_value = grid_value[sorting_indices]
+        grid_dec = grid_dec[sorting_indices]
+        grid_ra = grid_ra[sorting_indices]
+        uniq_array = uniq_array[sorting_indices]
+
     return grid_value, grid_ra, grid_dec, equatorial_map, uniq_array
 
 

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -90,13 +90,7 @@ def extract_map(
     grid_value: np.ndarray = np.asarray(grid_value_list)
     uniq_array: np.ndarray = np.asarray(uniq_list)
 
-    sorting_indices = np.argsort(grid_value)
-    grid_value = grid_value[sorting_indices]
-    grid_dec = grid_dec[sorting_indices]
-    grid_ra = grid_ra[sorting_indices]
-    uniq_array = uniq_array[sorting_indices]
-
-    min_value = grid_value[0]
+    min_value = np.min(grid_value)
 
     if remove_min_val or (not llh_map):
         # renormalize
@@ -111,6 +105,7 @@ def extract_map(
         # show 2 * delta_LLH
         grid_value = grid_value * 2.
         equatorial_map *= 2.
+        sorting_indices = np.argsort(grid_value)
     else:
         # Convert to probability
         equatorial_map = np.exp(-1. * equatorial_map)
@@ -137,12 +132,12 @@ def extract_map(
             equatorial_map, np.pi/2 - grid_dec, grid_ra
         )
         grid_value = grid_value.clip(min_map, None)
-
         sorting_indices = np.argsort(-grid_value)
-        grid_value = grid_value[sorting_indices]
-        grid_dec = grid_dec[sorting_indices]
-        grid_ra = grid_ra[sorting_indices]
-        uniq_array = uniq_array[sorting_indices]
+
+    grid_value = grid_value[sorting_indices]
+    grid_dec = grid_dec[sorting_indices]
+    grid_ra = grid_ra[sorting_indices]
+    uniq_array = uniq_array[sorting_indices]
 
     return grid_value, grid_ra, grid_dec, equatorial_map, uniq_array
 

--- a/skyreader/utils/handle_map_data.py
+++ b/skyreader/utils/handle_map_data.py
@@ -90,7 +90,7 @@ def extract_map(
     grid_value: np.ndarray = np.asarray(grid_value_list)
     uniq_array: np.ndarray = np.asarray(uniq_list)
 
-    min_value = np.min(grid_value)
+    min_value = np.nanmin(grid_value)
 
     if remove_min_val or (not llh_map):
         # renormalize


### PR DESCRIPTION
The switch to a probability map is applied  (with an eventual Gaussian smoothing) to the `equatorial_map`. This is subsequently applied to `grid_value` (the actual multiorder map) through an interpolation. Both the Gaussian smoothing and the interpolation can slightly change the position of the best-fit direction. Previously, the best-fit direction was taken from `grid_value` before the Gaussian smoothing and the interpolation. This created mismatches between the best-fit direction in the header and the actual best-fit direction in the multiorder map. The pull request aims to fix this by taking the best-fit direction after the application of smoothing and interpolation.