### PR TITLE
Rename I3TYPE to EVENT-TYPE in plotting_tools.py

### DIFF
--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -37,7 +37,7 @@ def format_fits_header(
         ('SENDER', 'IceCube Collaboration'),
         ('DATE-OBS', t.isot, 'UTC date of the observation'),
         ('MJD-OBS', mjd, 'modified Julian date of the observation'),
-        ('I3TYPE', f'{event_type}','Alert Type'),
+        ('ALERT-TYPE', f'{event_type}','Alert Type'),
         ('RA', np.round(ra,2),'Degree'),
         ('DEC', np.round(dec,2),'Degree'),
         ('RA_ERR_PLUS_50', np.round(uncertainties[0][0][1],2),

--- a/skyreader/plot/plotting_tools.py
+++ b/skyreader/plot/plotting_tools.py
@@ -37,7 +37,7 @@ def format_fits_header(
         ('SENDER', 'IceCube Collaboration'),
         ('DATE-OBS', t.isot, 'UTC date of the observation'),
         ('MJD-OBS', mjd, 'modified Julian date of the observation'),
-        ('ALERT-TYPE', f'{event_type}','Alert Type'),
+        ('EVENT-TYPE', f'{event_type}','Event Type'),
         ('RA', np.round(ra,2),'Degree'),
         ('DEC', np.round(dec,2),'Degree'),
         ('RA_ERR_PLUS_50', np.round(uncertainties[0][0][1],2),


### PR DESCRIPTION
I'd propose to change I3TYPE to EVENT-TYPE in the header of fits files, in view of their upcoming public release for high-energy track alerts. 
I think it's clearer for outsiders, as I3TYPE refers to i3 files, that is only IceCube-related.
What do you think?

Also, my idea is to then add, directly through skymist functions, a new item to the header, i.e., ALERT-TYPE, that can be Bronze or Gold (See https://github.com/icecube/skymist/blob/e5aabba08d27e220f5aec3e4871e4b4be2a62a69/src/skymist/gcn/gcn.py#L206-L224, used here https://github.com/icecube/skymist/blob/e5aabba08d27e220f5aec3e4871e4b4be2a62a69/src/skymist/gcn/gcn.py#L309)
