### PR TITLE
Add function that checks fermi sources within the real 90% contour 

### DIFF
--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -589,8 +589,8 @@ class SkyScanPlotter:
         )
 
         if plot_fermi_sources:
-            #sources_in_90 = self._save_sources_inside_90_box(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, rectangular_errors["90"])
-            sources_in_90 = self._save_sources_inside_90_contour(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, contours_by_levels[1])
+            # sources_in_90 = self._save_sources_inside_90_box(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, rectangular_errors["90"])
+            sources_in_90 = self._save_sources_inside_90_contour(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, contours_by_level[1])
 
         if plot_bounding_box:
             bounding_ras_list, bounding_decs_list = [], []
@@ -835,7 +835,6 @@ class SkyScanPlotter:
             )
         return sources_in_90
         
-
     def _save_sources_inside_90_box(self, ra_best_fit, dec_best_fit, ra_src, dec_src, name_src, rectangular_errors):
         src_inside_90_name, src_inside_90_ra, src_inside_90_dec = self._sources_inside_90_box(
             ra_best_fit,

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -15,8 +15,8 @@ import meander  # type: ignore[import]
 import numpy as np
 from astropy.io import ascii  # type: ignore[import]
 from matplotlib import patheffects
-from matplotlib import pyplot as plt
-from matplotlib import text
+from matplotlib import pyplot as pl
+from matplotlib import tex
 from matplotlib.projections import projection_registry  # type: ignore[import]
 
 from .plotting_tools import (
@@ -39,7 +39,7 @@ from ..utils.handle_map_data import (
     prepare_flattened_map,
     prepare_multiorder_map,
 )
-from ..result import SkyScanResult
+from ..result import SkyScanResul
 
 LOGGER = logging.getLogger("skyreader.plot")
 
@@ -52,7 +52,7 @@ class SkyScanPlotter:
     PLOT_COLORMAP = matplotlib.colormaps['plasma_r']
 
     def __init__(self, output_dir: Path = Path(".")):
-        # Set here plotting parameters and things that
+        # Set here plotting parameters and things tha
         # do not depend on the individual scan.
         self.output_dir = output_dir
         projection_registry.register(AstroMollweideAxes)
@@ -66,7 +66,7 @@ class SkyScanPlotter:
     ) -> None:
         """Creates a full-sky plot using a meshgrid at fixed resolution.
         Optionally creates a zoomed-in plot. Resolutions are defined in
-        PLOT_DPI_STANDARD and PLOT_DPI_ZOOMED. Zoomed mode is very inefficient
+        PLOT_DPI_STANDARD and PLOT_DPI_ZOOMED. Zoomed mode is very inefficien
         as the meshgrid is created for the full sky.
         """
         dpi = self.PLOT_DPI_STANDARD
@@ -144,7 +144,7 @@ class SkyScanPlotter:
         LOGGER.info(f"Preparing plot: {plot_filename}...")
 
         # features of the color map to use
-        cmap.set_under(alpha=0.)  # make underflows transparent
+        cmap.set_under(alpha=0.)  # make underflows transparen
         cmap.set_bad(alpha=1., color=(1., 0., 0.))  # make NaNs bright red
 
         # prepare the figure canvas
@@ -154,7 +154,7 @@ class SkyScanPlotter:
 
         ax = None
 
-        cmap.set_over(alpha=0.)  # make underflows transparent
+        cmap.set_over(alpha=0.)  # make underflows transparen
         ax = fig.add_subplot(111, projection='astro mollweide')
 
         # rasterized makes the map bitmap while the labels remain vectorial
@@ -197,7 +197,7 @@ class SkyScanPlotter:
 
         # cb.ax.xaxis.labelpad = -8
         # workaround for issue with viewers, see colorbar docstring
-        # mypy compliance: since cb.solids could be None, we check that
+        # mypy compliance: since cb.solids could be None, we check tha
         # it is actually a valid object before accessing i
         if isinstance(cb.solids, matplotlib.collections.QuadMesh):
             cb.solids.set_edgecolor("face")
@@ -209,7 +209,7 @@ class SkyScanPlotter:
         ax.grid(True, color='k', alpha=0.5)
 
         # Otherwise, add the path effects.
-        # mypy requires set_path_effects() to take a list of AbstractPathEffect
+        # mypy requires set_path_effects() to take a list of AbstractPathEffec
         effects: List[patheffects.AbstractPathEffect] = [
             patheffects.withStroke(linewidth=1.1, foreground='w')
         ]
@@ -477,7 +477,7 @@ class SkyScanPlotter:
             orientation='horizontal',
             aspect=50,
             ticks=ticks,
-            format=format
+            format=forma
         )
         cb.ax.xaxis.set_label_text(cb_label)
 
@@ -634,7 +634,7 @@ class SkyScanPlotter:
             bounding_contour_area = abs(calculate_area(bounding_contour.T))
             # convert to square-degrees
             bounding_contour_area *= (180.*180.)/(np.pi*np.pi)
-            contour_label = r'90% Bounding rectangle' + \
+            contour_label = r'90% Bounding rectangle' +
                 f' - area: {bounding_contour_area:.2f} sqdeg'
             healpy.projplot(
                 bounding_theta,
@@ -744,7 +744,7 @@ class SkyScanPlotter:
         plt.close()
         if plot_fermi_sources:
             return sources_in_90
-            
+
     def _sources_inside_90_contour(self, ra_src, dec_src, name_src, contours):
         # Convert inputs to numpy arrays
         name_src = np.asarray(name_src)
@@ -765,7 +765,7 @@ class SkyScanPlotter:
             contour_phi = contour[:, 1]
             # Build polygon in (theta, phi) space
             poly = np.column_stack([contour_theta, contour_phi])
-            # Create a 2D path object for point-in-polygon test
+            # Create a 2D path object for point-in-polygon tes
             path = Path(poly)
             # Update mask: mark sources inside this contour as True
             inside_mask |= path.contains_points(points)
@@ -812,13 +812,13 @@ class SkyScanPlotter:
                 "name": name,
                 "ra": ra_src,
                 "dec": dec_src,
-                "ang_dist": dist
+                "ang_dist": dis
             }
             for name, ra_src, dec_src, dist in zip(
                 src_inside_90_name,
                 src_inside_90_ra,
                 src_inside_90_dec,
-                ang_dist
+                ang_dis
             )
         ]
         sources_in_90_sorted = sorted(
@@ -834,7 +834,7 @@ class SkyScanPlotter:
                 f"  ang_dist: {s['ang_dist']:.3f} deg\n"
             )
         return sources_in_90
-        
+
     def _save_sources_inside_90_box(self, ra_best_fit, dec_best_fit, ra_src, dec_src, name_src, rectangular_errors):
         src_inside_90_name, src_inside_90_ra, src_inside_90_dec = self._sources_inside_90_box(
             ra_best_fit,
@@ -857,13 +857,13 @@ class SkyScanPlotter:
                 "name": name,
                 "ra": ra_src,
                 "dec": dec_src,
-                "ang_dist": dist
+                "ang_dist": dis
             }
             for name, ra_src, dec_src, dist in zip(
                 src_inside_90_name,
                 src_inside_90_ra,
                 src_inside_90_dec,
-                ang_dist
+                ang_dis
             )
         ]
         sources_in_90_sorted = sorted(

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -281,6 +281,7 @@ class SkyScanPlotter:
         systematics=False,
         plot_bounding_box=False,
         plot_fermi_sources=False,
+        check_fermi_sources_box=False,
         circular=False,
         circular_err50=0.2,
         circular_err90=0.7,
@@ -590,8 +591,10 @@ class SkyScanPlotter:
         )
 
         if plot_fermi_sources:
-            # sources_in_90 = self._save_sources_inside_90_box(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, rectangular_errors["90"])
-            sources_in_90 = self._save_sources_inside_90_contour(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, contours_by_level[1])
+            if check_fermi_sources_box:
+                sources_in_90 = self._save_sources_inside_90_box(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, rectangular_errors["90"])
+            else:
+                sources_in_90 = self._save_sources_inside_90_contour(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, contours_by_level[1])
 
         if plot_bounding_box:
             bounding_ras_list, bounding_decs_list = [], []

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -818,7 +818,7 @@ class SkyScanPlotter:
                 src_inside_90_name,
                 src_inside_90_ra,
                 src_inside_90_dec,
-                ang_dis
+                ang_dist
             )
         ]
         sources_in_90_sorted = sorted(

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -17,6 +17,7 @@ from astropy.io import ascii  # type: ignore[import]
 from matplotlib import patheffects
 from matplotlib import pyplot as plt
 from matplotlib import text
+from matplotlib.path import Path as PolyPath
 from matplotlib.projections import projection_registry  # type: ignore[import]
 
 from .plotting_tools import (
@@ -766,7 +767,7 @@ class SkyScanPlotter:
             # Build polygon in (theta, phi) space
             poly = np.column_stack([contour_theta, contour_phi])
             # Create a 2D path object for point-in-polygon test
-            path = Path(poly)
+            path = PolyPath(poly)
             # Update mask: mark sources inside this contour as True
             inside_mask |= path.contains_points(points)
         return name_src[inside_mask], ra_src[inside_mask], dec_src[inside_mask]

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -15,8 +15,8 @@ import meander  # type: ignore[import]
 import numpy as np
 from astropy.io import ascii  # type: ignore[import]
 from matplotlib import patheffects
-from matplotlib import pyplot as pl
-from matplotlib import tex
+from matplotlib import pyplot as plt
+from matplotlib import text
 from matplotlib.projections import projection_registry  # type: ignore[import]
 
 from .plotting_tools import (
@@ -39,7 +39,7 @@ from ..utils.handle_map_data import (
     prepare_flattened_map,
     prepare_multiorder_map,
 )
-from ..result import SkyScanResul
+from ..result import SkyScanResult
 
 LOGGER = logging.getLogger("skyreader.plot")
 
@@ -52,7 +52,7 @@ class SkyScanPlotter:
     PLOT_COLORMAP = matplotlib.colormaps['plasma_r']
 
     def __init__(self, output_dir: Path = Path(".")):
-        # Set here plotting parameters and things tha
+        # Set here plotting parameters and things that
         # do not depend on the individual scan.
         self.output_dir = output_dir
         projection_registry.register(AstroMollweideAxes)
@@ -66,7 +66,7 @@ class SkyScanPlotter:
     ) -> None:
         """Creates a full-sky plot using a meshgrid at fixed resolution.
         Optionally creates a zoomed-in plot. Resolutions are defined in
-        PLOT_DPI_STANDARD and PLOT_DPI_ZOOMED. Zoomed mode is very inefficien
+        PLOT_DPI_STANDARD and PLOT_DPI_ZOOMED. Zoomed mode is very inefficient
         as the meshgrid is created for the full sky.
         """
         dpi = self.PLOT_DPI_STANDARD
@@ -144,7 +144,7 @@ class SkyScanPlotter:
         LOGGER.info(f"Preparing plot: {plot_filename}...")
 
         # features of the color map to use
-        cmap.set_under(alpha=0.)  # make underflows transparen
+        cmap.set_under(alpha=0.)  # make underflows transparent
         cmap.set_bad(alpha=1., color=(1., 0., 0.))  # make NaNs bright red
 
         # prepare the figure canvas
@@ -154,7 +154,7 @@ class SkyScanPlotter:
 
         ax = None
 
-        cmap.set_over(alpha=0.)  # make underflows transparen
+        cmap.set_over(alpha=0.)  # make underflows transparent
         ax = fig.add_subplot(111, projection='astro mollweide')
 
         # rasterized makes the map bitmap while the labels remain vectorial
@@ -197,7 +197,7 @@ class SkyScanPlotter:
 
         # cb.ax.xaxis.labelpad = -8
         # workaround for issue with viewers, see colorbar docstring
-        # mypy compliance: since cb.solids could be None, we check tha
+        # mypy compliance: since cb.solids could be None, we check that
         # it is actually a valid object before accessing i
         if isinstance(cb.solids, matplotlib.collections.QuadMesh):
             cb.solids.set_edgecolor("face")
@@ -209,7 +209,7 @@ class SkyScanPlotter:
         ax.grid(True, color='k', alpha=0.5)
 
         # Otherwise, add the path effects.
-        # mypy requires set_path_effects() to take a list of AbstractPathEffec
+        # mypy requires set_path_effects() to take a list of AbstractPathEffect
         effects: List[patheffects.AbstractPathEffect] = [
             patheffects.withStroke(linewidth=1.1, foreground='w')
         ]
@@ -477,7 +477,7 @@ class SkyScanPlotter:
             orientation='horizontal',
             aspect=50,
             ticks=ticks,
-            format=forma
+            format=format
         )
         cb.ax.xaxis.set_label_text(cb_label)
 
@@ -634,7 +634,7 @@ class SkyScanPlotter:
             bounding_contour_area = abs(calculate_area(bounding_contour.T))
             # convert to square-degrees
             bounding_contour_area *= (180.*180.)/(np.pi*np.pi)
-            contour_label = r'90% Bounding rectangle' +
+            contour_label = r'90% Bounding rectangle' + \
                 f' - area: {bounding_contour_area:.2f} sqdeg'
             healpy.projplot(
                 bounding_theta,
@@ -765,7 +765,7 @@ class SkyScanPlotter:
             contour_phi = contour[:, 1]
             # Build polygon in (theta, phi) space
             poly = np.column_stack([contour_theta, contour_phi])
-            # Create a 2D path object for point-in-polygon tes
+            # Create a 2D path object for point-in-polygon test
             path = Path(poly)
             # Update mask: mark sources inside this contour as True
             inside_mask |= path.contains_points(points)
@@ -812,7 +812,7 @@ class SkyScanPlotter:
                 "name": name,
                 "ra": ra_src,
                 "dec": dec_src,
-                "ang_dist": dis
+                "ang_dist": dist
             }
             for name, ra_src, dec_src, dist in zip(
                 src_inside_90_name,
@@ -857,13 +857,13 @@ class SkyScanPlotter:
                 "name": name,
                 "ra": ra_src,
                 "dec": dec_src,
-                "ang_dist": dis
+                "ang_dist": dist
             }
             for name, ra_src, dec_src, dist in zip(
                 src_inside_90_name,
                 src_inside_90_ra,
                 src_inside_90_dec,
-                ang_dis
+                ang_dist
             )
         ]
         sources_in_90_sorted = sorted(

--- a/skyreader/plot/plot.py
+++ b/skyreader/plot/plot.py
@@ -589,7 +589,8 @@ class SkyScanPlotter:
         )
 
         if plot_fermi_sources:
-            sources_in_90 = self._save_sources_inside_90_box(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, rectangular_errors["90"])
+            #sources_in_90 = self._save_sources_inside_90_box(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, rectangular_errors["90"])
+            sources_in_90 = self._save_sources_inside_90_contour(ra, dec, ra_fermi_sources, dec_fermi_sources, name_fermi_sources, contours_by_levels[1])
 
         if plot_bounding_box:
             bounding_ras_list, bounding_decs_list = [], []
@@ -743,6 +744,32 @@ class SkyScanPlotter:
         plt.close()
         if plot_fermi_sources:
             return sources_in_90
+            
+    def _sources_inside_90_contour(self, ra_src, dec_src, name_src, contours):
+        # Convert inputs to numpy arrays
+        name_src = np.asarray(name_src)
+        ra_src = np.asarray(ra_src, dtype=float) % 360.0
+        dec_src = np.asarray(dec_src, dtype=float)
+        # Convert (RA, Dec) → spherical coordinates used by healpy
+        # theta = colatitude (0 = North pole, pi = South pole)
+        # phi   = longitude
+        src_theta = np.pi/2 - np.deg2rad(dec_src)
+        src_phi = np.deg2rad(ra_src)
+        # Combine coordinates into point array: (theta, phi)
+        points = np.column_stack([src_theta, src_phi])
+        # Initialize mask: False for all sources initially
+        inside_mask = np.zeros(len(points), dtype=bool)
+        for contour in contours:
+            # contour is (theta, phi)
+            contour_theta = contour[:, 0]
+            contour_phi = contour[:, 1]
+            # Build polygon in (theta, phi) space
+            poly = np.column_stack([contour_theta, contour_phi])
+            # Create a 2D path object for point-in-polygon test
+            path = Path(poly)
+            # Update mask: mark sources inside this contour as True
+            inside_mask |= path.contains_points(points)
+        return name_src[inside_mask], ra_src[inside_mask], dec_src[inside_mask]
 
     def _sources_inside_90_box(self, ra_best_fit, dec_best_fit, ra_src, dec_src, name_src, rectangular_errors):
         ra_min = ra_best_fit + rectangular_errors["ra_minus"]
@@ -764,6 +791,50 @@ class SkyScanPlotter:
             ra_ok = (ra_src >= ra_min) | (ra_src <= ra_max)
         mask = ra_ok & dec_ok
         return name_src[mask], ra_src[mask], dec_src[mask]
+
+    def _save_sources_inside_90_contour(self, ra_best_fit, dec_best_fit, ra_src, dec_src, name_src, contour):
+        src_inside_90_name, src_inside_90_ra, src_inside_90_dec = self._sources_inside_90_contour(
+            ra_src,
+            dec_src,
+            name_src,
+            contour
+        )
+        ang_dist = np.zeros(len(src_inside_90_name), dtype=float)
+        for i in range(len(src_inside_90_name)):
+            ang_dist[i] = pyasl.getAngDist(
+                ra_best_fit,
+                dec_best_fit,
+                src_inside_90_ra[i],
+                src_inside_90_dec[i]
+            )
+        sources_in_90 = [
+            {
+                "name": name,
+                "ra": ra_src,
+                "dec": dec_src,
+                "ang_dist": dist
+            }
+            for name, ra_src, dec_src, dist in zip(
+                src_inside_90_name,
+                src_inside_90_ra,
+                src_inside_90_dec,
+                ang_dist
+            )
+        ]
+        sources_in_90_sorted = sorted(
+            sources_in_90,
+            key=lambda s: s["ang_dist"]
+        )
+        print("\nFermi sources inside 90% contour:\n")
+        for s in sources_in_90_sorted:
+            print(
+                f"- {s['name'].strip()}\n"
+                f"  RA: {s['ra']:.3f} deg\n"
+                f"  Dec: {s['dec']:.3f} deg\n"
+                f"  ang_dist: {s['ang_dist']:.3f} deg\n"
+            )
+        return sources_in_90
+        
 
     def _save_sources_inside_90_box(self, ra_best_fit, dec_best_fit, ra_src, dec_src, name_src, rectangular_errors):
         src_inside_90_name, src_inside_90_ra, src_inside_90_dec = self._sources_inside_90_box(


### PR DESCRIPTION
Update with respect to the recent release, to check Fermi sources within the actual contour.
The user can choose, through the option [check_fermi_sources_box](https://github.com/icecube/skyreader/blob/11b5524f9c40c3e11f3d13025187b9475a060264/skyreader/plot/plot.py#L284), if checking from Fermi sources within the rectangular error box or the actual contour available from the map.

I've done some tests on these options installing in realtime containers the SkyReader version corresponding to this branch.

Example for the last alert (plot below)
 
<img width="1366" height="868" alt="Screenshot 2026-06-18 alle 18 08 06" src="https://github.com/user-attachments/assets/5fb510a0-5d19-476f-87d7-bf77538d2b76" />

Output setting `check_fermi_sources_box=True`

> SkyMist  [18:06]
> [skymist@39b278d8ed5b] -- 
> Fermi sources inside 90%:
>     - FL16Y J2035.0+3632
>       RA [deg]: 308.768 deg
>       Dec [deg]: 36.539 deg
>       Angular distance from IceCube best fit: 0.760 deg
>       Primary associated source: PSR J2034+3632
>       Source classification: MSP
>       Secondary associated source: 
>       Source classification:       TeV source?: N
>       Associated TeV source: 
> 
>   --- 4FGL association ---
>       Source name in 4FGL: 4FGL J2035.0+3632
>       Primary associated source: PSR J2034+3632
>       Source classification: MSP
>       Secondary associated source: 
>       Source classification:       TeV source?: N
>       Associated TeV source: 
>       RA [deg] in 4FGL: 308.7571105957031
>       DEC [deg] in 4FGL: 36.53710174560547
>       Light Curve Repository: https://fermi.gsfc.nasa.gov/ssc/data/access/lat/LightCurveRepository/source.html?source_name=4FGL_J2035.0+3632
> 
>     - FL16Y J2030.0+3641
>       RA [deg]: 307.505 deg
>       Dec [deg]: 36.692 deg
>       Angular distance from IceCube best fit: 1.451 deg
>       Primary associated source: PSR J2030+3641
>       Source classification: PSR
>       Secondary associated source: 
>       Source classification:       TeV source?: N
>       Associated TeV source: 
> 
>   --- 4FGL association ---
>       Source name in 4FGL: 4FGL J2030.0+3641
>       Primary associated source: PSR J2030+3641
>       Source classification: PSR
>       Secondary associated source: 
>       Source classification:       TeV source?: N
>       Associated TeV source: 
>       RA [deg] in 4FGL: 307.50860595703125
>       DEC [deg] in 4FGL: 36.687198638916016
>       Light Curve Repository: https://fermi.gsfc.nasa.gov/ssc/data/access/lat/LightCurveRepository/source.html?source_name=4FGL_J2030.0+3641

Output setting `check_fermi_sources_box=False`

> SkyMist  [17:27]
> [skymist@90beea090bc6] -- 
> Fermi sources inside 90%:
>     - FL16Y J2035.0+3632
>       RA [deg]: 308.768 deg
>       Dec [deg]: 36.539 deg
>       Angular distance from IceCube best fit: 0.760 deg
>       Primary associated source: PSR J2034+3632
>       Source classification: MSP
>       Secondary associated source: 
>       Source classification:       TeV source?: N
>       Associated TeV source: 
> 
>   --- 4FGL association ---
>       Source name in 4FGL: 4FGL J2035.0+3632
>       Primary associated source: PSR J2034+3632
>       Source classification: MSP
>       Secondary associated source: 
>       Source classification:       TeV source?: N
>       Associated TeV source: 
>       RA [deg] in 4FGL: 308.7571105957031
>       DEC [deg] in 4FGL: 36.53710174560547
>       Light Curve Repository: https://fermi.gsfc.nasa.gov/ssc/data/access/lat/LightCurveRepository/source.html?source_name=4FGL_J2035.0+3632

You see that in the latter case FL16Y J2030.0+3641 doesn't appear anymore, as expected.
